### PR TITLE
feat(session-cleanup): delete a session after it has been used

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -16,7 +16,21 @@ export class SessionManager {
   async getSession(accessToken?: string) {
     await this.createSessions(accessToken);
     this.createAndWaitForSession(accessToken);
-    return this.sessions.pop();
+    const session = this.sessions.pop();
+    return session;
+  }
+
+  async clearSession(id: string, accessToken?: string) {
+    const deleteSessionRequest = {
+      method: "DELETE",
+      headers: this.getHeaders(accessToken),
+    };
+    return await this.request<Session>(
+      `${this.serverUrl}/compute/sessions/${id}`,
+      deleteSessionRequest
+    ).then(() => {
+      this.sessions = this.sessions.filter((s) => s.id !== id);
+    });
   }
 
   private async createSessions(accessToken?: string) {

--- a/src/utils/makeRequest.ts
+++ b/src/utils/makeRequest.ts
@@ -44,24 +44,32 @@ export async function makeRequest<T>(
         if (needsRetry(body)) {
           if (retryCount < retryLimit) {
             retryCount++;
-            let retryResponse =  await makeRequest(url, retryRequest || request, callback, contentType);
+            let retryResponse = await makeRequest(
+              url,
+              retryRequest || request,
+              callback,
+              contentType
+            );
             retryCount = 0;
-  
+
             return retryResponse;
           } else {
             retryCount = 0;
-            
-            throw new Error('Request retry limit exceeded');
+
+            throw new Error("Request retry limit exceeded");
           }
         }
-        
+
         return Promise.reject({ status: response.status, body });
       }
     } else {
+      if (response.status === 204) {
+        return Promise.resolve();
+      }
       const responseTransformed = await responseTransform(response);
-      let responseText = '';
+      let responseText = "";
 
-      if (typeof responseTransformed === 'string') {
+      if (typeof responseTransformed === "string") {
         responseText = responseTransformed;
       } else {
         responseText = JSON.stringify(responseTransformed);
@@ -70,18 +78,23 @@ export async function makeRequest<T>(
       if (response.redirected && response.url.includes("SASLogon/login")) {
         return Promise.reject({ status: 401, responseTransformed });
       }
-      
+
       if (needsRetry(responseText)) {
         if (retryCount < retryLimit) {
           retryCount++;
-          let retryResponse =  await makeRequest(url, retryRequest || request, callback, contentType);
+          const retryResponse = await makeRequest(
+            url,
+            retryRequest || request,
+            callback,
+            contentType
+          );
           retryCount = 0;
 
           return retryResponse;
         } else {
           retryCount = 0;
-          
-          throw new Error('Request retry limit exceeded');
+
+          throw new Error("Request retry limit exceeded");
         }
       }
 

--- a/src/utils/needsRetry.ts
+++ b/src/utils/needsRetry.ts
@@ -1,11 +1,14 @@
 export const needsRetry = (responseText: string): boolean => {
   return (
-    (responseText.includes('"errorCode":403') &&
+    !!responseText &&
+    ((responseText.includes('"errorCode":403') &&
       responseText.includes("_csrf") &&
       responseText.includes("X-CSRF-TOKEN")) ||
-    (responseText.includes('"status":403') &&
-      responseText.includes('"error":"Forbidden"')) ||
-    (responseText.includes('"status":449') &&
-      responseText.includes("Authentication success, retry original request"))
+      (responseText.includes('"status":403') &&
+        responseText.includes('"error":"Forbidden"')) ||
+      (responseText.includes('"status":449') &&
+        responseText.includes(
+          "Authentication success, retry original request"
+        )))
   );
 };


### PR DESCRIPTION
# Intent
Clean up after using a session, to minimise resource usage on the SAS server.

# Implementation
* Added `clearSession` method in `SessionManager`.
* Call `clearSession` after each job execution.

# Other changes
* Fixed linting errors.
* Removed redundant `sessionId` parameter as we have determined that sessions can't be reused.