### PR TITLE
fix: job definition debug log parse

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,4 @@ export * from "./parseSourceCode";
 export * from "./parseSasViyaLog";
 export * from "./serialize";
 export * from "./splitChunks";
+export * from "./parseWeboutResponse";

--- a/src/utils/parseWeboutResponse.ts
+++ b/src/utils/parseWeboutResponse.ts
@@ -1,0 +1,16 @@
+export const parseWeboutResponse = (response: string) => {
+    let sasResponse = "";
+
+    if (response.includes(">>weboutBEGIN<<")) {
+      try {
+        sasResponse = response
+          .split(">>weboutBEGIN<<")[1]
+          .split(">>weboutEND<<")[0];
+      } catch (e) {
+        sasResponse = "";
+        console.error(e);
+      }
+    }
+
+    return sasResponse;
+}


### PR DESCRIPTION
## Problem
When debug is on, response is between the `WEBOUTBEGIN<< and >>weboutEND<<`.
That is not a valid JSON so it triggered error while doing `JSON.parse()`.
Problem was on 3 places:
- Appending sasjs request
- executeJob
- executeComputeJob

## Solution
Wrapping `JSON.parse()` with `try-catch` block and in `catch` block we parse response before passing it to `JSON.parse()`