### PR TITLE
fix(session-expiry-retry): retry job with new session on expiry

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -17,6 +17,16 @@ export class SessionManager {
     await this.createSessions(accessToken);
     this.createAndWaitForSession(accessToken);
     const session = this.sessions.pop();
+    const secondsSinceSessionCreation =
+      (new Date().getTime() - new Date(session!.creationTimeStamp).getTime()) /
+      1000;
+    if (
+      secondsSinceSessionCreation >= session!.attributes.sessionInactiveTimeout
+    ) {
+      await this.createSessions(accessToken);
+      const freshSession = this.sessions.pop();
+      return freshSession;
+    }
     return session;
   }
 

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -4,4 +4,8 @@ export interface Session {
   id: string;
   state: string;
   links: Link[];
+  attributes: {
+    sessionInactiveTimeout: number;
+  };
+  creationTimeStamp: string;
 }


### PR DESCRIPTION
* Added `try`/`catch` blocks to `executeScript`.
* When a 404 is caught, retry the job execution.
* When any other error is caught, pass it on to the caller.

# SessionManager
* Check if a session has been inactive for longer than the timeout value.
* If a session has expired, discard it, create a fresh session and return.
* Else, return the original session.