### PR TITLE
fix(jes-job-execution): prevent file upload requests failing with invalid CSRF token

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Issue
+
+Link any related issue(s) in this section.
+
+## Intent
+
+What this PR intends to achieve.
+
+## Implementation
+
+What code changes have been made to achieve the intent.
+
+## Checks
+
+- [ ] Code is formatted correctly (`npm run lint:fix`).
+- [ ] All unit tests are passing (`npm test`).
+- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).

--- a/sasjs-tests/package-lock.json
+++ b/sasjs-tests/package-lock.json
@@ -1357,9 +1357,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@sasjs/adapter": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.3.13.tgz",
-      "integrity": "sha512-dWcDxgY3FB7Yx1I5dPpeQeyJDu4lezhIFrjn6lbdwRhV15aqOt4l9o9qZP+VbgOXqyi9gN0Y+p+vs2chBDFQqg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.12.0.tgz",
+      "integrity": "sha512-0uGQH9ynomWzdBaEujEtcR38q6V7LCgG0mrb1Wellv6cC/IHD3j6WfeZZAgtiMPeOSJjbCDBOlVnzC2TlBqJFw==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",

--- a/sasjs-tests/package.json
+++ b/sasjs-tests/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "private": true,
   "dependencies": {
-    "@sasjs/adapter": "^1.3.13",
+    "@sasjs/adapter": "^1.12.0",
     "@sasjs/test-framework": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/sasjs-tests/src/testSuites/RequestData.ts
+++ b/sasjs-tests/src/testSuites/RequestData.ts
@@ -88,7 +88,7 @@ export const sendArrTests = (adapter: SASjs): TestSuite => ({
         return adapter.request("common/sendArr", data).catch((e) => e);
       },
       assertion: (error: any) => {
-        return !!error && !!error.MESSAGE;
+        return !!error && !!error.body && !!error.body.message;
       }
     },
     {
@@ -185,7 +185,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
         };
         return adapter.request("common/sendObj", invalidData).catch((e) => e);
       },
-      assertion: (error: any) => !!error && !!error.MESSAGE
+      assertion: (error: any) => !!error && !!error.body && !!error.body.message
     },
     {
       title: "Single string value",
@@ -219,7 +219,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           .catch((e) => e);
       },
       assertion: (error: any) => {
-        return !!error && !!error.MESSAGE;
+        return !!error && !!error.body && !!error.body.message;
       }
     },
     {


### PR DESCRIPTION
Fixes https://github.com/sasjs/adapter/issues/97, https://github.com/sasjs/adapter/issues/98

# Intent
When using the JES API approach, each file upload request and any immediate next request fails and is retried because the CSRF token is invalid. This causes a significant drop in performance due to the overhead involved in making the extra requests each time.

# Implementation
It turns out that the CSRF token used for most operations does not work for file upload, and the other way around.
So here's what fixes it:
* Maintain a separate CSRF token for file uploads.
* Use this token when a file upload request is made.
* For all other requests, use the normal token we always had.

# Additional Changes
* Fix failing tests in `sasjs-tests`.
* Bump adapter version.

## Checks
- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-tests` are passing.
Tests available at https://sas.analytium.co.uk/kriaco/sasjs-tests-jes