### PR TITLE
Access token missed

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -932,7 +932,10 @@ export class SASViyaApiClient {
 
     if (isRelativePath(sasJob)) {
       const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`, accessToken)
+      await this.populateFolderMap(
+        `${this.rootFolderName}/${folderName}`,
+        accessToken
+      )
 
       if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
         throw new Error(
@@ -1029,7 +1032,10 @@ export class SASViyaApiClient {
 
     if (isRelativePath(sasJob)) {
       const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`, accessToken)
+      await this.populateFolderMap(
+        `${this.rootFolderName}/${folderName}`,
+        accessToken
+      )
 
       if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
         throw new Error(

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -932,7 +932,7 @@ export class SASViyaApiClient {
 
     if (isRelativePath(sasJob)) {
       const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`)
+      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`, accessToken)
 
       if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
         throw new Error(
@@ -1029,7 +1029,7 @@ export class SASViyaApiClient {
 
     if (isRelativePath(sasJob)) {
       const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`)
+      await this.populateFolderMap(`${this.rootFolderName}/${folderName}`, accessToken)
 
       if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
         throw new Error(


### PR DESCRIPTION
## Issue

No related issue

## Intent

In some function calls, access token hasn't been passed. So that was triggering errors when calling `request` from `CLI` with access token.

## Implementation

`accessToken` has been added to function call parameter.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).

---

![image](https://user-images.githubusercontent.com/18329105/94056399-8ab66e00-fdde-11ea-84ac-7cd76ae6f606.png)