### PR TITLE
fix: ErrorResponse body changed to error

### DIFF
--- a/src/types/ErrorResponse.ts
+++ b/src/types/ErrorResponse.ts
@@ -1,5 +1,5 @@
 export class ErrorResponse {
-  body: ErrorBody
+  error: ErrorBody
 
   constructor(message: string, details?: any) {
     let detailsString = ''
@@ -11,7 +11,7 @@ export class ErrorResponse {
       raw = details
     }
 
-    this.body = {
+    this.error = {
       message,
       details: detailsString,
       raw


### PR DESCRIPTION
## Intent

Name `body` ErrorResponse doesn't make much sense, changed it to `error`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/18329105/95311938-99952a00-088e-11eb-91c5-b0037a0ccca6.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
