### PR TITLE
fix: viya login issue

### DIFF
--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -38,6 +38,17 @@ export const basicTests = (
         response && response.isLoggedIn && response.userName === userName
     },
     {
+      title: "Multiple Log in attempts",
+      description: "Should fail on first attempt and should log the user in on second attempt",
+      test: async () => {
+        await adapter.logOut()
+        await adapter.logIn('invalid', 'invalid')
+        return adapter.logIn(userName, password)
+      },
+      assertion: (response: any) =>
+        response && response.isLoggedIn && response.userName === userName
+    },
+    {
       title: "Default config",
       description:
         "Should instantiate with default config when none is provided",

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -415,22 +415,22 @@ export default class SASjs {
     const pattern: RegExp = /<form.+action="(.*Logon[^"]*).*>/
     const matches = pattern.exec(response)
     const formInputs: any = {}
-    
+
     if (matches && matches.length) {
       this.setLoginUrl(matches)
       const inputs = response.match(/<input.*"hidden"[^>]*>/g)
-    
+
       if (inputs) {
         inputs.forEach((inputStr: string) => {
           const valueMatch = inputStr.match(/name="([^"]*)"\svalue="([^"]*)/)
-    
+
           if (valueMatch && valueMatch.length) {
             formInputs[valueMatch[1]] = valueMatch[2]
           }
         })
       }
     }
-    
+
     return Object.keys(formInputs).length ? formInputs : null
   }
 

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -411,6 +411,29 @@ export default class SASjs {
     }
   }
 
+  private async getLoginForm(response: any) {
+    const pattern: RegExp = /<form.+action="(.*Logon[^"]*).*>/
+    const matches = pattern.exec(response)
+    const formInputs: any = {}
+    
+    if (matches && matches.length) {
+      this.setLoginUrl(matches)
+      const inputs = response.match(/<input.*"hidden"[^>]*>/g)
+    
+      if (inputs) {
+        inputs.forEach((inputStr: string) => {
+          const valueMatch = inputStr.match(/name="([^"]*)"\svalue="([^"]*)/)
+    
+          if (valueMatch && valueMatch.length) {
+            formInputs[valueMatch[1]] = valueMatch[2]
+          }
+        })
+      }
+    }
+    
+    return Object.keys(formInputs).length ? formInputs : null
+  }
+
   /**
    * Checks whether a session is active, or login is required.
    * @returns - a promise which resolves with an object containing two values - a boolean `isLoggedIn`, and a string `userName`.
@@ -419,10 +442,16 @@ export default class SASjs {
     const loginResponse = await fetch(this.loginUrl.replace('.do', ''))
     const responseText = await loginResponse.text()
     const isLoggedIn = /<button.+onClick.+logout/gm.test(responseText)
+    let loginForm: any = null
+
+    if (!isLoggedIn) {
+      loginForm = await this.getLoginForm(responseText)
+    }
 
     return Promise.resolve({
       isLoggedIn,
-      userName: this.userName
+      userName: this.userName,
+      loginForm
     })
   }
 
@@ -440,7 +469,7 @@ export default class SASjs {
 
     this.userName = loginParams.username
 
-    const { isLoggedIn } = await this.checkSession()
+    const { isLoggedIn, loginForm } = await this.checkSession()
     if (isLoggedIn) {
       this.resendWaitingRequests()
 
@@ -450,15 +479,13 @@ export default class SASjs {
       })
     }
 
-    const loginForm = await this.getLoginForm()
-
     for (const key in loginForm) {
       loginParams[key] = loginForm[key]
     }
     const loginParamsStr = serialize(loginParams)
 
     return fetch(this.loginUrl, {
-      method: 'post',
+      method: 'POST',
       credentials: 'include',
       referrerPolicy: 'same-origin',
       body: loginParamsStr,
@@ -1483,26 +1510,6 @@ export default class SASjs {
           ? tempLoginLink
           : loginUrl.replace('.do', '')
     }
-  }
-
-  private async getLoginForm() {
-    const pattern: RegExp = /<form.+action="(.*Logon[^"]*).*>/
-    const response = await fetch(this.loginUrl).then((r) => r.text())
-    const matches = pattern.exec(response)
-    const formInputs: any = {}
-    if (matches && matches.length) {
-      this.setLoginUrl(matches)
-      const inputs = response.match(/<input.*"hidden"[^>]*>/g)
-      if (inputs) {
-        inputs.forEach((inputStr: string) => {
-          const valueMatch = inputStr.match(/name="([^"]*)"\svalue="([^"]*)/)
-          if (valueMatch && valueMatch.length) {
-            formInputs[valueMatch[1]] = valueMatch[2]
-          }
-        })
-      }
-    }
-    return Object.keys(formInputs).length ? formInputs : null
   }
 
   private async createFoldersAndServices(


### PR DESCRIPTION
## Issue

Closes #117 

## Intent

Fix for the viya login issue, after one login attempt, all other attempts would fail, with both valid and invalid credentials.

## Implementation

`getLoginForm` function fetches the login page, and takes data from it, that will be used in our login request. The most important piece is `CSRF token`.
Function was fetching the login page with login link that includes suffix `.do` and that works on first attempt but on the other attempts, that url is invalid. Solution was to use login link without `.do` all the time.
I took I chance and did small refactor, so now we have one call request less when doing a login procedure.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/18329105/99529499-31af2480-29a0-11eb-91c4-a74b717b100e.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
