### PR TITLE
fix(job execute): details for failing job

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -574,7 +574,7 @@ export class SASViyaApiClient {
       }
 
       if (jobStatus === 'failed' || jobStatus === 'error') {
-        return Promise.reject({ result: currentJob, log })
+        return Promise.reject({ job: currentJob, log })
       }
 
       let resultLink

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -574,7 +574,7 @@ export class SASViyaApiClient {
       }
 
       if (jobStatus === 'failed' || jobStatus === 'error') {
-        return Promise.reject({ error: currentJob.error, log })
+        return Promise.reject({ result: currentJob, log })
       }
 
       let resultLink


### PR DESCRIPTION
## Issue

We need to display log and job status in case of failing job.

## Intent

It will be passing job data back to cli

## Implementation

In promise reject, now passing complete data object that's needed in cli.
There's no such property `currentJob.error`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
![image](https://user-images.githubusercontent.com/8914650/100028772-752ae800-2e11-11eb-8697-1a93dc7f1cdc.png)
