### PR TITLE
Issue157

### DIFF
--- a/sasjs-tests/package-lock.json
+++ b/sasjs-tests/package-lock.json
@@ -1357,9 +1357,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@sasjs/adapter": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.12.0.tgz",
-      "integrity": "sha512-0uGQH9ynomWzdBaEujEtcR38q6V7LCgG0mrb1Wellv6cC/IHD3j6WfeZZAgtiMPeOSJjbCDBOlVnzC2TlBqJFw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.3.tgz",
+      "integrity": "sha512-wzDFJRyt2dXFeQP+JzqRGunYUbujrAbU/Jc4IWg5URsCkGAzwsNl/4G0xJVbqOTy1MvoZ431rfCnvhkUlg7D3Q==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",

--- a/sasjs-tests/package.json
+++ b/sasjs-tests/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "private": true,
   "dependencies": {
-    "@sasjs/adapter": "^1.12.0",
+    "@sasjs/adapter": "^1.18.2",
     "@sasjs/test-framework": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/sasjs-tests/src/App.test.js
+++ b/sasjs-tests/src/App.test.js
@@ -1,9 +1,0 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -3,12 +3,12 @@ import { TestSuite } from "@sasjs/test-framework";
 
 const defaultConfig: SASjsConfig = {
   serverUrl: window.location.origin,
-  pathSAS9: "/SASStoredProcess/do",
-  pathSASViya: "/SASJobExecution",
-  appLoc: "/Public/seedapp",
+  pathSAS9: '/SASStoredProcess/do',
+  pathSASViya: '/SASJobExecution',
+  appLoc: '/Public/seedapp',
   serverType: ServerType.SASViya,
-  debug: true,
-  contextName: "SAS Job Execution compute context",
+  debug: false,
+  contextName: 'SAS Job Execution compute context',
   useComputeApi: false
 };
 
@@ -57,6 +57,7 @@ export const basicTests = (
       },
       assertion: (sasjsInstance: SASjs) => {
         const sasjsConfig = sasjsInstance.getSasjsConfig();
+
         return (
           sasjsConfig.serverUrl === defaultConfig.serverUrl &&
           sasjsConfig.pathSAS9 === defaultConfig.pathSAS9 &&

--- a/sasjs-tests/src/testSuites/RequestData.ts
+++ b/sasjs-tests/src/testSuites/RequestData.ts
@@ -88,7 +88,7 @@ export const sendArrTests = (adapter: SASjs): TestSuite => ({
         return adapter.request("common/sendArr", data).catch((e) => e);
       },
       assertion: (error: any) => {
-        return !!error && !!error.body && !!error.body.message;
+        return !!error && !!error.error && !!error.error.message;
       }
     },
     {
@@ -185,7 +185,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
         };
         return adapter.request("common/sendObj", invalidData).catch((e) => e);
       },
-      assertion: (error: any) => !!error && !!error.body && !!error.body.message
+      assertion: (error: any) => !!error && !!error.error && !!error.error.message
     },
     {
       title: "Single string value",
@@ -219,7 +219,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           .catch((e) => e);
       },
       assertion: (error: any) => {
-        return !!error && !!error.body && !!error.body.message;
+        return !!error && !!error.error && !!error.error.message;
       }
     },
     {

--- a/sasjs-tests/src/testSuites/SasjsRequests.ts
+++ b/sasjs-tests/src/testSuites/SasjsRequests.ts
@@ -27,7 +27,7 @@ export const sasjsRequestTests = (adapter: SASjs): TestSuite => ({
       test: async () => {
         return new Promise(async (resolve, reject) => {
           adapter
-            .request("common/makeErr", data)
+            .request("common/makeErr", data, {debug: true})
             .then((res) => {
               //no action here, this request must throw error
             })

--- a/sasjs-tests/src/testSuites/SasjsRequests.ts
+++ b/sasjs-tests/src/testSuites/SasjsRequests.ts
@@ -23,7 +23,7 @@ export const sasjsRequestTests = (adapter: SASjs): TestSuite => ({
     },
     {
       title: "Make error and capture log",
-      description: "Should make an error and capture log",
+      description: "Should make an error and capture log, in the same time it is testing if debug override is working",
       test: async () => {
         return new Promise(async (resolve, reject) => {
           adapter
@@ -33,12 +33,14 @@ export const sasjsRequestTests = (adapter: SASjs): TestSuite => ({
             })
             .catch((err) => {
               let sasRequests = adapter.getSasRequests();
-              let makeErrRequest =
+              let makeErrRequest: any =
                 sasRequests.find((req) =>
                   req.serviceLink.includes("makeErr")
                 ) || null;
 
-              resolve(!!makeErrRequest);
+              if (!makeErrRequest) resolve(false)
+
+              resolve(!!(makeErrRequest.logFile && makeErrRequest.logFile.length > 0));
             });
         });
       },

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -426,10 +426,10 @@ export class SASViyaApiClient {
    * @param linesOfCode - an array of code lines to execute.
    * @param contextName - the context to execute the code in.
    * @param accessToken - an access token for an authorized user.
-   * @param sessionId - optional session ID to reuse.
    * @param data - execution data.
    * @param debug - when set to true, the log will be returned.
    * @param expectWebout - when set to true, the automatic _webout fileref will be checked for content, and that content returned. This fileref is used when the Job contains a SASjs web request (as opposed to executing arbitrary SAS code).
+   * @param waitForResult - when set to true, function will return the session
    */
   public async executeScript(
     jobPath: string,
@@ -437,6 +437,7 @@ export class SASViyaApiClient {
     contextName: string,
     accessToken?: string,
     data = null,
+    debug: boolean = false,
     expectWebout = false,
     waitForResult = true
   ): Promise<any> {
@@ -467,7 +468,7 @@ export class SASViyaApiClient {
         _OMITTEXTLOG: true
       }
 
-      if (this.debug) {
+      if (debug) {
         jobArguments['_OMITTEXTLOG'] = false
         jobArguments['_OMITSESSIONRESULTS'] = false
         jobArguments['_DEBUG'] = 131
@@ -535,7 +536,7 @@ export class SASViyaApiClient {
         return session
       }
 
-      if (this.debug) {
+      if (debug) {
         console.log(`Job has been submitted for '${fileName}'.`)
         console.log(
           `You can monitor the job progress at '${this.serverUrl}${
@@ -558,7 +559,7 @@ export class SASViyaApiClient {
 
       const logLink = currentJob.links.find((l) => l.rel === 'log')
 
-      if (this.debug && logLink) {
+      if (debug && logLink) {
         log = await this.request<any>(
           `${this.serverUrl}${logLink.href}/content?limit=10000`,
           {
@@ -633,6 +634,7 @@ export class SASViyaApiClient {
           contextName,
           accessToken,
           data,
+          debug,
           false,
           true
         )
@@ -953,6 +955,7 @@ export class SASViyaApiClient {
   public async executeComputeJob(
     sasJob: string,
     contextName: string,
+    debug?: boolean,
     data?: any,
     accessToken?: string,
     waitForResult = true,
@@ -1039,6 +1042,7 @@ export class SASViyaApiClient {
       contextName,
       accessToken,
       data,
+      debug,
       expectWebout,
       waitForResult
     )

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -606,12 +606,10 @@ export class SASViyaApiClient {
                   throw err
                 })
 
-              return Promise.reject(
-                new ErrorResponse('Job execution failed.', {
-                  status: 500,
-                  body: log
-                })
-              )
+              return Promise.reject({
+                status: 500,
+                log: log
+              })
             }
           }
           return {

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -895,8 +895,8 @@ export default class SASjs {
 
                 return responseJson
               })
-              .catch(async (e) => {
-                if (needsRetry(JSON.stringify(e))) {
+              .catch(async (response) => {
+                if (needsRetry(JSON.stringify(response))) {
                   if (this.retryCountJeseApi < requestRetryLimit) {
                     let retryResponse = await this.executeJobViaJesApi(
                       sasJob,
@@ -917,11 +917,11 @@ export default class SASjs {
                   }
                 }
 
-                if (e?.log) {
-                  this.appendSasjsRequest(e.log, sasJob, null)
+                if (response?.log) {
+                  this.appendSasjsRequest(response.log, sasJob, null)
                 }
 
-                if (e.toString().includes('Job was not found')) {
+                if (response.toString().includes('Job was not found')) {
                   reject(
                     new ErrorResponse('Service not found on the server.', {
                       sasJob: sasJob
@@ -929,7 +929,7 @@ export default class SASjs {
                   )
                 }
 
-                reject(new ErrorResponse('Job execution failed.', e))
+                reject(new ErrorResponse('Job execution failed.', response))
               })
           )
         }

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -734,6 +734,7 @@ export default class SASjs {
     return this.sasViyaApiClient?.executeComputeJob(
       sasJob,
       config.contextName,
+      config.debug,
       data,
       accessToken,
       !!waitForResult,
@@ -766,6 +767,7 @@ export default class SASjs {
           ?.executeComputeJob(
             sasJob,
             config.contextName,
+            config.debug,
             data,
             accessToken,
             waitForResult,


### PR DESCRIPTION
## Issue

Closes #157 

## Intent

Compute API request method, was not appending log to `sasjs requests` when service has error and does not finish.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/18329105/100091969-a4fbdf00-2e55-11eb-9c4d-559b19b93777.png)
- [x] All `sasjs-tests` unit tests are passing (`npm test`).
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
