### PR TITLE
fix(*): export type declarations for node version of adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+node

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@ What code changes have been made to achieve the intent.
 
 - [ ] Code is formatted correctly (`npm run lint:fix`).
 - [ ] All unit tests are passing (`npm test`).
-- [ ] All `sasjs-tests` unit tests are passing (`npm test`).
+- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
 - [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sasjs/adapter",
   "description": "JavaScript adapter for SAS",
   "scripts": {
-    "build": "rimraf build && webpack",
+    "build": "rimraf build && rimraf node && mkdir node && cp -r src/* node && webpack && rimraf build/src",
     "package:lib": "npm run build && cp ./package.json build && cd build && npm version \"5.0.0\" && npm pack",
     "publish:lib": "npm run build && cd build && npm publish",
     "lint:fix": "npx prettier --write 'src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ const browserConfig = {
 const nodeConfig = {
   ...browserConfig,
   target: 'node',
+  entry: './node/index.ts',
   output: {
     ...browserConfig.output,
     path: path.resolve(__dirname, 'build', 'node')


### PR DESCRIPTION
## Issue

https://github.com/sasjs/adapter/issues/160

## Intent

Fix the build process to export type declarations for both browser and node versions of the adapter.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-tests` unit tests are passing (`npm test`).
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
https://sas.analytium.co.uk/kriaco/sasjs-tests-build/#/
