### PR TITLE
fix(session-status): fixed stop polling session status

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -168,7 +168,11 @@ export class SessionManager {
     const stateLink = session.links.find((l: any) => l.rel === 'state')
 
     return new Promise(async (resolve, _) => {
-      if (sessionState === 'pending') {
+      if (
+        sessionState === 'pending' ||
+        sessionState === 'running' ||
+        sessionState === ''
+      ) {
         if (stateLink) {
           if (this.debug) {
             console.log('Polling session status... \n') // ?


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/317

## Intent

Continue polling session status if session status is equal to `running` or an empty string.

## Implementation

![image](https://user-images.githubusercontent.com/25773492/101613400-c4316980-3a1c-11eb-8963-e4790785192c.png)

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/101613469-d9a69380-3a1c-11eb-9c0b-d37c609307c4.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/101613566-f5119e80-3a1c-11eb-936d-51dac7b3135b.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
