### PR TITLE
fix(deploy-service-pack): deploy services into 'services' subfolder

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -747,10 +747,7 @@ export default class SASjs {
       )
     }
 
-    const members =
-      serviceJson.members[0].name === 'services'
-        ? serviceJson.members[0].members
-        : serviceJson.members
+    const members = serviceJson.members
 
     await this.createFoldersAndServices(
       appLoc,


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/302

## Intent

Deploy services into a `services` subfolder rather than at the root of the `appLoc`.

## Implementation

Remove special case for `services` folder.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
