### PR TITLE
fix(relative-paths): process relative and absolute paths the same way

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -833,23 +833,20 @@ export class SASViyaApiClient {
       )
     }
 
-    if (isRelativePath(sasJob)) {
-      const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(
-        `${this.rootFolderName}/${folderName}`,
-        accessToken
-      )
+    const folderPathParts = sasJob.split('/')
+    const jobName = folderPathParts.pop()
+    const folderPath = folderPathParts.join('/')
+    const fullFolderPath = isRelativePath(sasJob)
+      ? `${this.rootFolderName}/${folderPath}`
+      : folderPath
 
-      if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
-        throw new Error(
-          `The folder '${folderName}' was not found at '${this.serverUrl}/${this.rootFolderName}'`
-        )
-      }
-    } else {
-      const folderPathParts = sasJob.split('/')
-      folderPathParts.pop()
-      const folderPath = folderPathParts.join('/')
-      await this.populateFolderMap(folderPath, accessToken)
+    await this.populateFolderMap(fullFolderPath, accessToken)
+
+    const jobFolder = this.folderMap.get(fullFolderPath)
+    if (!jobFolder) {
+      throw new Error(
+        `The folder '${fullFolderPath}' was not found on '${this.serverUrl}'`
+      )
     }
 
     const headers: any = { 'Content-Type': 'application/json' }
@@ -857,21 +854,7 @@ export class SASViyaApiClient {
       headers.Authorization = `Bearer ${accessToken}`
     }
 
-    let jobToExecute
-    if (isRelativePath(sasJob)) {
-      const folderName = sasJob.split('/')[0]
-      const jobName = sasJob.split('/')[1]
-      const jobFolder = this.folderMap.get(
-        `${this.rootFolderName}/${folderName}`
-      )
-      jobToExecute = jobFolder?.find((item) => item.name === jobName)
-    } else {
-      const folderPathParts = sasJob.split('/')
-      const jobName = folderPathParts.pop()
-      const folderPath = folderPathParts.join('/')
-      const jobFolder = this.folderMap.get(folderPath)
-      jobToExecute = jobFolder?.find((item) => item.name === jobName)
-    }
+    const jobToExecute = jobFolder?.find((item) => item.name === jobName)
 
     if (!jobToExecute) {
       throw new Error(`Job was not found.`)
@@ -937,50 +920,26 @@ export class SASViyaApiClient {
       )
     }
 
-    if (isRelativePath(sasJob)) {
-      const folderName = sasJob.split('/')[0]
-      await this.populateFolderMap(
-        `${this.rootFolderName}/${folderName}`,
-        accessToken
-      )
+    const folderPathParts = sasJob.split('/')
+    const jobName = folderPathParts.pop()
+    const folderPath = folderPathParts.join('/')
+    const fullFolderPath = isRelativePath(sasJob)
+      ? `${this.rootFolderName}/${folderPath}`
+      : folderPath
+    await this.populateFolderMap(fullFolderPath, accessToken)
 
-      if (!this.folderMap.get(`${this.rootFolderName}/${folderName}`)) {
-        throw new Error(
-          `The folder '${folderName}' was not found at '${this.serverUrl}/${this.rootFolderName}'.`
-        )
-      }
-    } else {
-      const folderPathParts = sasJob.split('/')
-      folderPathParts.pop()
-      const folderPath = folderPathParts.join('/')
-      await this.populateFolderMap(folderPath, accessToken)
-      if (!this.folderMap.get(folderPath)) {
-        throw new Error(
-          `The folder '${folderPath}' was not found at '${this.serverUrl}'.`
-        )
-      }
+    const jobFolder = this.folderMap.get(fullFolderPath)
+    if (!jobFolder) {
+      throw new Error(
+        `The folder '${fullFolderPath}' was not found on '${this.serverUrl}'.`
+      )
     }
+
+    const jobToExecute = jobFolder?.find((item) => item.name === jobName)
 
     let files: any[] = []
     if (data && Object.keys(data).length) {
       files = await this.uploadTables(data, accessToken)
-    }
-
-    let jobToExecute: Job | undefined
-    let jobName: string | undefined
-    let jobPath: string | undefined
-    if (isRelativePath(sasJob)) {
-      const folderName = sasJob.split('/')[0]
-      jobName = sasJob.split('/')[1]
-      jobPath = `${this.rootFolderName}/${folderName}`
-      const jobFolder = this.folderMap.get(jobPath)
-      jobToExecute = jobFolder?.find((item) => item.name === jobName)
-    } else {
-      const folderPathParts = sasJob.split('/')
-      jobName = folderPathParts.pop()
-      jobPath = folderPathParts.join('/')
-      const jobFolder = this.folderMap.get(jobPath)
-      jobToExecute = jobFolder?.find((item) => item.name === jobName)
     }
 
     if (!jobToExecute) {
@@ -1007,7 +966,7 @@ export class SASViyaApiClient {
 
     const jobArguments: { [key: string]: any } = {
       _contextName: contextName,
-      _program: `${jobPath}/${jobName}`,
+      _program: `${fullFolderPath}/${jobName}`,
       _webin_file_count: files.length,
       _OMITJSONLISTING: true,
       _OMITJSONLOG: true,


### PR DESCRIPTION
## Issue

https://github.com/sasjs/adapter/issues/202

## Intent

Process relative and absolute paths the same way, so that relative paths with multiple nested folders can be specified with `sasjs request`.


## Implementation

Standardise how we process paths.
The only difference between absolute and relative paths now, is that we don't append the appLoc in the beginning for absolute paths.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
