### PR TITLE
fix: when admin group is not accepted, login does not work

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -101,9 +101,7 @@ export class AuthManager {
       loginForm = await this.getLoginForm(responseText)
     } else {
       //Send request to /folders/folders to trigger Assumable Gropups form
-      const foldersResponse = await fetch(
-        `${this.serverUrl}/folders/folders`
-      )
+      const foldersResponse = await fetch(`${this.serverUrl}/folders/folders`)
       const foldersResponseText = await foldersResponse.text()
 
       if (isAuthorizeFormRequired(foldersResponseText)) {

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -101,9 +101,7 @@ export class AuthManager {
       loginForm = await this.getLoginForm(responseText)
     } else {
       //Send request to /folders/folders to trigger Assumable Groups form
-      const foldersResponse = await fetch(
-        `${this.serverUrl}/folders/folders`
-      )
+      const foldersResponse = await fetch(`${this.serverUrl}/folders/folders`)
       const foldersResponseText = await foldersResponse.text()
 
       if (isAuthorizeFormRequired(foldersResponseText)) {

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -99,6 +99,16 @@ export class AuthManager {
 
     if (!isLoggedIn) {
       loginForm = await this.getLoginForm(responseText)
+    } else {
+      //Send request to /folders/folders to trigger Assumable Gropups form
+      const foldersResponse = await fetch(
+        `${this.serverUrl}/folders/folders`
+      )
+      const foldersResponseText = await foldersResponse.text()
+
+      if (isAuthorizeFormRequired(foldersResponseText)) {
+        await this.requestClient.authorize(foldersResponseText)
+      }
     }
 
     return Promise.resolve({

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -101,11 +101,13 @@ export class AuthManager {
       loginForm = await this.getLoginForm(responseText)
     } else {
       //Send request to /folders/folders to trigger Assumable Groups form
-      const foldersResponse = await fetch(`${this.serverUrl}/folders/folders`)
-      const foldersResponseText = await foldersResponse.text()
+      const { result: foldersResponse } = await this.requestClient.get<string>(
+        `${this.serverUrl}/folders/folders`,
+        undefined
+      )
 
-      if (isAuthorizeFormRequired(foldersResponseText)) {
-        await this.requestClient.authorize(foldersResponseText)
+      if (isAuthorizeFormRequired(foldersResponse)) {
+        await this.requestClient.authorize(foldersResponse)
       }
     }
 

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -5,7 +5,6 @@ import { LoginRequiredError } from '../types'
 import { AuthorizeError } from '../types/AuthorizeError'
 import { NotFoundError } from '../types/NotFoundError'
 import { parseWeboutResponse } from '../utils/parseWeboutResponse'
-import * as https from 'https'
 
 export interface HttpClient {
   get<T>(
@@ -45,6 +44,7 @@ export class RequestClient implements HttpClient {
   private httpClient: AxiosInstance
 
   constructor(private baseUrl: string, allowInsecure = false) {
+    const https = require('https')
     this.httpClient = axios.create({
       baseURL: baseUrl,
       httpsAgent: new https.Agent({


### PR DESCRIPTION
## Issue

Closes #222 

## Intent

On every login, check is made to make sure admin groups are accepted, if not it will accept them automatically.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/18329105/107208323-b8a0f580-6a01-11eb-9a81-1470604580b9.png)

---
These checks should be done in the main branch

- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
