### PR TITLE
fix(startComputeJob): improved error handling

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -64,7 +64,7 @@ export class SessionManager {
         this.sessions = this.sessions.filter((s) => s.id !== id)
       })
       .catch((err) => {
-        throw err
+        throw prefixMessage(err, 'Error while deleting session. ')
       })
   }
 


### PR DESCRIPTION
## Intent

Improve error handling in `startComputeJob` method to catch unhandled promise rejection in `sasjs flow execute` command.

## Implementation

What code changes have been made to achieve the intent.

1. Updated `executeScript` method.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [X] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/108982998-73d2bb00-769f-11eb-814e-830b93df7e15.png)
- [X] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/25773492/108983071-877e2180-769f-11eb-8a96-3efe4a1ffd3c.png)
Server:
![image](https://user-images.githubusercontent.com/25773492/108983100-8fd65c80-769f-11eb-965c-74e4af79fb71.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
