### PR TITLE
fix(RequestClient): improved handleError method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 .env
 
 /coverage
+
+.DS_Store

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -381,7 +381,7 @@ export class RequestClient implements HttpClient {
     throw e
   }
 
-  private async parseResponse<T>(response: AxiosResponse<any>) {
+  private parseResponse<T>(response: AxiosResponse<any>) {
     const etag = response?.headers ? response.headers['etag'] : ''
     let parsedResponse
 


### PR DESCRIPTION
## Intent

Handle unhandled promise rejection in `sasjs flow execute` command.

## Implementation

Added `catch` block in `handleError` method of `RequestClient`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/109113984-19dcfe80-774e-11eb-859d-2f2571d04282.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/25773492/109114006-24979380-774e-11eb-9079-0da00c587dcc.png)
Server:
![image](https://user-images.githubusercontent.com/25773492/109114052-311bec00-774e-11eb-930d-142a59d380ab.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
