### PR TITLE
fix(RequestClient): add catch block to authorize method

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -346,7 +346,9 @@ export class RequestClient implements HttpClient {
         })
 
       if (isAuthorizeFormRequired(res?.data as string)) {
-        await this.authorize(res.data as string)
+        await this.authorize(res.data as string).catch((err) => {
+          throw prefixMessage(err, 'Error while authorizing request. ')
+        })
       }
 
       return await callback().catch((err: any) => {


### PR DESCRIPTION
## Intent

Catch unhandled promise rejection in `startComputeJob` method.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
