### PR TITLE
fix: fetch session log for session failed/stopped state

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -412,7 +412,22 @@ export class SASViyaApiClient {
         etag,
         accessToken,
         pollOptions
-      ).catch((err) => {
+      ).catch(async (err) => {
+        const error = err?.response?.data
+        const result = /err=[0-9]*,/.exec(error)
+
+        const errorCode = '5113'
+        if (result?.[0]?.slice(4, -1) === errorCode) {
+          const sessionLogUrl =
+            postedJob.links.find((l: any) => l.rel === 'up')!.href + '/log'
+          const logCount = 1000000
+          err.log = await fetchLogByChunks(
+            this.requestClient,
+            accessToken!,
+            sessionLogUrl,
+            logCount
+          )
+        }
         throw prefixMessage(err, 'Error while polling job status. ')
       })
 


### PR DESCRIPTION
## Intent

For `unable to fetch job's log`, fetch session log, if session is failed or in stopped state.

## Implementation

Handled case where getting job info and unable to get it due to session failed/stopped.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).

mocked: 
![image](https://user-images.githubusercontent.com/8914650/116891247-eb950700-ac47-11eb-95d3-626f1a289912.png)

server:
![image](https://user-images.githubusercontent.com/8914650/116894405-70cdeb00-ac4b-11eb-81ad-44462a60fbbb.png)


- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
