### PR TITLE
fix(job-state-poll): Continue poll regardless of errors

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -594,15 +594,16 @@ export class SASViyaApiClient {
       }
     }
 
-    const { result: createFolderResponse } =
-      await this.requestClient.post<Folder>(
-        `/folders/folders?parentFolderUri=${parentFolderUri}`,
-        {
-          name: folderName,
-          type: 'folder'
-        },
-        accessToken
-      )
+    const {
+      result: createFolderResponse
+    } = await this.requestClient.post<Folder>(
+      `/folders/folders?parentFolderUri=${parentFolderUri}`,
+      {
+        name: folderName,
+        type: 'folder'
+      },
+      accessToken
+    )
 
     // update folder map with newly created folder.
     await this.populateFolderMap(
@@ -874,7 +875,9 @@ export class SASViyaApiClient {
         throw new Error(`URI of job definition was not found.`)
       }
 
-      const { result: jobDefinition } = await this.requestClient
+      const {
+        result: jobDefinition
+      } = await this.requestClient
         .get<JobDefinition>(
           `${this.serverUrl}${jobDefinitionLink.href}`,
           accessToken
@@ -1107,7 +1110,11 @@ export class SASViyaApiClient {
         this.debug
       )
       .catch((err) => {
-        throw prefixMessage(err, 'Error while getting job state. ')
+        console.error(
+          'Error fetching job state. Starting poll, assuming job to be running.',
+          err
+        )
+        return { result: 'running' }
       })
 
     const currentState = state.trim()
@@ -1134,10 +1141,17 @@ export class SASViyaApiClient {
                 this.debug
               )
               .catch((err) => {
-                throw prefixMessage(
-                  err,
-                  'Error while getting job state after interval. '
+                if (pollCount >= MAX_POLL_COUNT) {
+                  throw prefixMessage(
+                    err,
+                    'Error while getting job state after interval. '
+                  )
+                }
+                console.error(
+                  'Error fetching job state. Resuming poll, assuming job to be running.',
+                  err
                 )
+                return { result: 'running' }
               })
 
             postedJobState = jobState.trim()

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -1101,6 +1101,9 @@ export class SASViyaApiClient {
       Promise.reject(`Job state link was not found.`)
     }
 
+    console.log(
+      `Attempting to poll job state from ${this.serverUrl}${stateLink.href}`
+    )
     const { result: state } = await this.requestClient
       .get<string>(
         `${this.serverUrl}${stateLink.href}?_action=wait&wait=300`,

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -1141,6 +1141,7 @@ export class SASViyaApiClient {
                 this.debug
               )
               .catch((err) => {
+                errorCount++
                 if (
                   pollCount >= MAX_POLL_COUNT ||
                   errorCount >= MAX_ERROR_COUNT

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -594,16 +594,15 @@ export class SASViyaApiClient {
       }
     }
 
-    const {
-      result: createFolderResponse
-    } = await this.requestClient.post<Folder>(
-      `/folders/folders?parentFolderUri=${parentFolderUri}`,
-      {
-        name: folderName,
-        type: 'folder'
-      },
-      accessToken
-    )
+    const { result: createFolderResponse } =
+      await this.requestClient.post<Folder>(
+        `/folders/folders?parentFolderUri=${parentFolderUri}`,
+        {
+          name: folderName,
+          type: 'folder'
+        },
+        accessToken
+      )
 
     // update folder map with newly created folder.
     await this.populateFolderMap(
@@ -875,9 +874,7 @@ export class SASViyaApiClient {
         throw new Error(`URI of job definition was not found.`)
       }
 
-      const {
-        result: jobDefinition
-      } = await this.requestClient
+      const { result: jobDefinition } = await this.requestClient
         .get<JobDefinition>(
           `${this.serverUrl}${jobDefinitionLink.href}`,
           accessToken

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -1101,9 +1101,6 @@ export class SASViyaApiClient {
       Promise.reject(`Job state link was not found.`)
     }
 
-    console.log(
-      `Attempting to poll job state from ${this.serverUrl}${stateLink.href}`
-    )
     const { result: state } = await this.requestClient
       .get<string>(
         `${this.serverUrl}${stateLink.href}?_action=wait&wait=300`,
@@ -1114,7 +1111,7 @@ export class SASViyaApiClient {
       )
       .catch((err) => {
         console.error(
-          'Error fetching job state. Starting poll, assuming job to be running.',
+          `Error fetching job state from ${this.serverUrl}${stateLink.href}. Starting poll, assuming job to be running.`,
           err
         )
         return { result: 'running' }
@@ -1151,7 +1148,7 @@ export class SASViyaApiClient {
                   )
                 }
                 console.error(
-                  'Error fetching job state. Resuming poll, assuming job to be running.',
+                  `Error fetching job state from ${this.serverUrl}${stateLink.href}. Resuming poll, assuming job to be running.`,
                   err
                 )
                 return { result: 'running' }

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -1078,7 +1078,7 @@ export class SASViyaApiClient {
   ) {
     let POLL_INTERVAL = 300
     let MAX_POLL_COUNT = 1000
-    let MAX_ERROR_COUNT = 10
+    let MAX_ERROR_COUNT = 5
 
     if (pollOptions) {
       POLL_INTERVAL = pollOptions.POLL_INTERVAL || POLL_INTERVAL


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/657

## Intent

Continue polling regardless of HTTP errors on the request to get a job's state, until `MAX_POLL_COUNT` has been exceeded.

## Implementation

* If there is an error on the initial fetch of the job state, assume the job status to be `running`.
* If there is an error during polling for the job state, continue polling while assuming the job status to be `running`.
* In both cases, log a message to the console.
* If there is an error during polling and the `MAX_POLL_COUNT` has been exceeded, throw an error.

* Minor formatting changes due to Prettier version upgrade.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).

![image](https://user-images.githubusercontent.com/2980428/117781139-3a3e3480-b238-11eb-8603-873a93909949.png)

- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
Tests are available at https://sas.analytium.co.uk/kriaco/sasjs-tests-poll
![image](https://user-images.githubusercontent.com/2980428/117781372-7d000c80-b238-11eb-970e-f7517e2d2e13.png)
