### PR TITLE
feat(git): enabled git hook enforcing conventional commits

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -1,0 +1,18 @@
+#!/bin/sh
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+
+# Get the commit message (the parameter we're given is just the path to the
+# temporary file which holds the message).
+commit_message=$(cat "$1")
+
+if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z \-]+\))?!?: .+$") then
+   echo "${GREEN} ✔ Commit message meets Conventional Commit standards"
+   exit 0
+fi
+
+echo "${RED}❌ Commit message does not meet the Conventional Commit standard!"
+echo "An example of a valid message is:"
+echo "  feat(login): add the 'remember me' button"
+echo "ℹ More details at: https://www.conventionalcommits.org/en/v1.0.0/#summary"
+exit 1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepublishOnly": "cp -r ./build/* . && rm -rf ./build",
     "postpublish": "git clean -fd",
     "semantic-release": "semantic-release",
-    "typedoc": "typedoc"
+    "typedoc": "typedoc",
+    "postinstall": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Intent

Enable pre-commit git hook enforcing conventional commits.

## Implementation

1. Added `.git-hooks/commit-msg`.
2. Added `postinstall` script to `package.json`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/118924122-4f584900-b945-11eb-915d-794be2321194.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
