### PR TITLE
fix(sas9-support): Throw error when invalid credentials are supplied

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -6,7 +6,7 @@ GREEN="\033[1;32m"
 # temporary file which holds the message).
 commit_message=$(cat "$1")
 
-if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z \-]+\))?!?: .+$") then
+if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9 \-]+\))?!?: .+$") then
    echo "${GREEN} ✔ Commit message meets Conventional Commit standards"
    exit 0
 fi

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -10,6 +10,7 @@ import {
 } from '../types/errors'
 import { parseWeboutResponse } from '../utils/parseWeboutResponse'
 import { prefixMessage } from '@sasjs/utils/error'
+import { SAS9AuthError } from '../types/errors/SAS9AuthError'
 
 export interface HttpClient {
   get<T>(
@@ -468,6 +469,10 @@ export const throwIfError = (response: AxiosResponse) => {
   if (response.data?.auth_request) {
     const authorizeRequestUrl = response.request.responseURL
     throw new AuthorizeError(response.data.message, authorizeRequestUrl)
+  }
+
+  if (response.config?.url?.includes('sasAuthError')) {
+    throw new SAS9AuthError()
   }
 
   const error = parseError(response.data as string)

--- a/src/types/errors/SAS9AuthError.ts
+++ b/src/types/errors/SAS9AuthError.ts
@@ -1,0 +1,9 @@
+export class SAS9AuthError extends Error {
+  constructor() {
+    super(
+      'The credentials you provided cannot be authenticated. Please provide a valid set of credentials.'
+    )
+    this.name = 'AuthorizeError'
+    Object.setPrototypeOf(this, SAS9AuthError.prototype)
+  }
+}


### PR DESCRIPTION
## Issue

No linked issues.

## Intent

Fail with a descriptive error when invalid credentials are provided.

## Implementation

* Throw a `SAS9AuthError` when the redirected URL contains the string `sasAuthError`.
* Modify git hooks regex to allow numbers in commit prefix.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`). - new tests are being added in my current CLI branch.
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
