### PR TITLE
fix: adding makeErr for SAS 9 in sajss-tests

### DIFF
--- a/sasjs-tests/README.md
+++ b/sasjs-tests/README.md
@@ -72,6 +72,10 @@ parmcards4;
   %webout(CLOSE)
 ;;;;
 %mm_createwebservice(path=/Public/app/common,name=sendArr)
+parmcards4;
+let he who hath understanding, reckon the number of the beast
+;;;;
+%mm_createwebservice(path=/Public/app/common,name=makeErr)
 ```
 
 ### SAS Viya


### PR DESCRIPTION
## Issue

adding makeErr service on sas9


