### PR TITLE
fix(webpack): removed process plugin from nodeConfig

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,19 +2,30 @@ const path = require('path')
 const webpack = require('webpack')
 const terserPlugin = require('terser-webpack-plugin')
 
+const defaultPlugins = [
+  new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
+  new webpack.SourceMapDevToolPlugin({
+    filename: null,
+    exclude: [/node_modules/],
+    test: /\.ts($|\?)/i
+  })
+]
+
+const optimization = {
+  minimize: true,
+  minimizer: [
+    new terserPlugin({
+      parallel: true,
+      terserOptions: {}
+    })
+  ]
+}
+
 const browserConfig = {
   entry: './src/index.ts',
   devtool: 'inline-source-map',
   mode: 'production',
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new terserPlugin({
-        parallel: true,
-        terserOptions: {}
-      })
-    ]
-  },
+  optimization: optimization,
   module: {
     rules: [
       {
@@ -35,20 +46,26 @@ const browserConfig = {
     library: 'SASjs'
   },
   plugins: [
-    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
-    new webpack.SourceMapDevToolPlugin({
-      filename: null,
-      exclude: [/node_modules/],
-      test: /\.ts($|\?)/i
-    }),
+    ...defaultPlugins,
     new webpack.ProvidePlugin({
       process: 'process/browser'
     })
   ]
 }
 
+const browserConfigWithoutProcessPlugin = {
+  entry: browserConfig.entry,
+  devtool: browserConfig.devtool,
+  mode: browserConfig.mode,
+  optimization: optimization,
+  module: browserConfig.module,
+  resolve: browserConfig.resolve,
+  output: browserConfig.output,
+  plugins: defaultPlugins
+}
+
 const nodeConfig = {
-  ...browserConfig,
+  ...browserConfigWithoutProcessPlugin,
   target: 'node',
   entry: './node/index.ts',
   output: {


### PR DESCRIPTION
## Intent

Wix project package.

## Implementation

Removed `process` plugin from `nodeConfig`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/121342632-81e4d880-c92a-11eb-9f5b-4183e689cd47.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/121342756-a345c480-c92a-11eb-8e82-7cabcc706c27.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
