### PR TITLE
fix(sas9): force webout output when executing arbitrary code on SAS9

### DIFF
--- a/src/SAS9ApiClient.ts
+++ b/src/SAS9ApiClient.ts
@@ -45,7 +45,9 @@ export class SAS9ApiClient {
   ) {
     await this.requestClient.login(userName, password, this.jobsPath)
 
-    const formData = generateFileUploadForm(linesOfCode.join('\n'))
+    // This piece of code forces a webout to prevent Stored Process Errors.
+    const forceOutputCode = ['data _null_;', 'file _webout;', `put 'Executed sasjs run';`, 'run;']
+    const formData = generateFileUploadForm([...linesOfCode, ...forceOutputCode].join('\n'))
 
     const codeInjectorPath = `/User Folders/${userName}/My Folder/sasjs/runner`
     const contentType =

--- a/src/SAS9ApiClient.ts
+++ b/src/SAS9ApiClient.ts
@@ -46,8 +46,15 @@ export class SAS9ApiClient {
     await this.requestClient.login(userName, password, this.jobsPath)
 
     // This piece of code forces a webout to prevent Stored Process Errors.
-    const forceOutputCode = ['data _null_;', 'file _webout;', `put 'Executed sasjs run';`, 'run;']
-    const formData = generateFileUploadForm([...linesOfCode, ...forceOutputCode].join('\n'))
+    const forceOutputCode = [
+      'data _null_;',
+      'file _webout;',
+      `put 'Executed sasjs run';`,
+      'run;'
+    ]
+    const formData = generateFileUploadForm(
+      [...linesOfCode, ...forceOutputCode].join('\n')
+    )
 
     const codeInjectorPath = `/User Folders/${userName}/My Folder/sasjs/runner`
     const contentType =


### PR DESCRIPTION
## Issue
No linked issue.

## Intent

Force `_webout` output when executing arbitrary code on SAS9 to prevent STP errors.

## Implementation

* Added some lines of code at the end of the user's code to force `_webout` output.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
```
I am currently in the process of adding more CLI tests here: https://github.com/sasjs/cli/tree/sas9-support
```