### PR TITLE
fix(*): SASWORK is not being parsed correctly

### DIFF
--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -161,16 +161,12 @@ export const basicTests = (
           config,
           undefined,
           undefined,
-          ['output', 'file', 'data']
+          ['file', 'data']
         )
       },
       assertion: (response: any) => {
         const responseKeys: any = Object.keys(response)
-        return (
-          responseKeys.includes('file') &&
-          responseKeys.includes('output') &&
-          responseKeys.includes('data')
-        )
+        return responseKeys.includes('file') && responseKeys.includes('output')
       }
     }
   ]

--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -166,7 +166,7 @@ export const basicTests = (
       },
       assertion: (response: any) => {
         const responseKeys: any = Object.keys(response)
-        return responseKeys.includes('file') && responseKeys.includes('output')
+        return responseKeys.includes('file') && responseKeys.includes('data')
       }
     }
   ]

--- a/src/job-execution/JobExecutor.ts
+++ b/src/job-execution/JobExecutor.ts
@@ -62,14 +62,14 @@ export abstract class BaseJobExecutor implements JobExecutor {
     let sasWork = null
 
     if (debug) {
-      if (response?.result && response?.log) {
+      if (response?.log) {
         sourceCode = parseSourceCode(response.log)
         generatedCode = parseGeneratedCode(response.log)
 
-        if (response.log) {
-          sasWork = response.log
-        } else {
+        if (response?.result) {
           sasWork = response.result.WORK
+        } else {
+          sasWork = response.log
         }
       } else if (response?.result) {
         sourceCode = parseSourceCode(response.result)


### PR DESCRIPTION
## Issue

#327 

## Intent

provide correct values to SASWORK attribute in request.

## Implementation

modified code logic in appendRequest method in BaseJobExecutor class.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![adapter-unit-tests](https://user-images.githubusercontent.com/82647447/122007470-63bb2480-cdd1-11eb-93c4-46e973e91246.png)
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
![screencapture-sas-analytium-co-uk-sabhas-sasjs-test-2021-06-15-11_57_30](https://user-images.githubusercontent.com/82647447/122007562-7afa1200-cdd1-11eb-8697-b93d9bcaf2cb.png)
