### PR TITLE
fix: on viya when calling api pass debug parameter to correct section

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -339,7 +339,6 @@ export class SASViyaApiClient {
       if (debug) {
         jobArguments['_OMITTEXTLOG'] = false
         jobArguments['_OMITSESSIONRESULTS'] = false
-        jobArguments['_DEBUG'] = 131
       }
 
       let fileName
@@ -361,6 +360,8 @@ export class SASViyaApiClient {
       }
 
       if (variables) jobVariables = { ...jobVariables, ...variables }
+
+      if (debug) jobVariables = { ...jobVariables, _DEBUG: 131 }
 
       let files: any[] = []
 


### PR DESCRIPTION
## Issue

closes #420

## Intent

pass the debug parameter to correct section i.e. variable not argument

## Implementation

adding  _DEBUG: 131 to jobVariable object if debug is  true

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all four of the items below are confirmed!  If an urgent fix is needed - use a tar file.

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
