### PR TITLE
fix(session): fixed polling session state

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postpublish": "git clean -fd",
     "semantic-release": "semantic-release",
     "typedoc": "typedoc",
-    "postinstall": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
+    "prepare": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
   },
   "publishConfig": {
     "access": "public"

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -63,6 +63,9 @@ export class RequestClient implements HttpClient {
         baseURL: baseUrl
       })
     }
+
+    this.httpClient.defaults.validateStatus = (status) =>
+      status >= 200 && status < 305
   }
 
   public getCsrfToken(type: 'general' | 'file' = 'general') {


### PR DESCRIPTION
## Intent

1. Handle server response with the status `304`.
2. Improve polling session status.

## Implementation

1. Overriden the range of valid response statuses in axios.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all four of the items below are confirmed!  If an urgent fix is needed - use a tar file.

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/123983455-8dc53700-d9cc-11eb-99d6-ff8b06f876fc.png)
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/83717836/123984748-8d796b80-d9cd-11eb-9169-341ad9f40b0d.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/123987831-2f01bc80-d9d0-11eb-8f50-69be4a8708db.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/124001511-6034b980-d9dd-11eb-8d14-0851a0813c25.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
