### PR TITLE
fix(fileUploader): parsing debug response for SASVIYA

### DIFF
--- a/src/FileUploader.ts
+++ b/src/FileUploader.ts
@@ -64,12 +64,9 @@ export class FileUploader {
     return this.requestClient
       .post(uploadUrl, formData, undefined, 'application/json', headers)
       .then(async (res) => {
-        // for web approach on Viya
         if (
-          this.sasjsConfig.debug &&
-          (this.sasjsConfig.useComputeApi === null ||
-            this.sasjsConfig.useComputeApi === undefined) &&
-          this.sasjsConfig.serverType === ServerType.SasViya
+          this.sasjsConfig.serverType === ServerType.SasViya &&
+          this.sasjsConfig.debug
         ) {
           const jsonResponse = await parseSasViyaDebugResponse(
             res.result as string,

--- a/src/FileUploader.ts
+++ b/src/FileUploader.ts
@@ -61,6 +61,8 @@ export class FileUploader {
       'Content-Type': 'text/plain'
     }
 
+    // currently only web approach is supported for file upload
+    // therefore log is part of response with debug enabled and must be parsed
     return this.requestClient
       .post(uploadUrl, formData, undefined, 'application/json', headers)
       .then(async (res) => {


### PR DESCRIPTION
## Issue

Fixes fileUploader [issue](https://github.com/sasjs/fileuploader/issues/2)

## Intent

Parse debug response correctly.

## Implementation

- removed additional checks while deciding to parse debug response for `SASVIYA`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/128715343-29ed55d1-09a5-4d4c-bd9a-e51ff8d68b57.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/128720376-a4b102c3-b09d-44d3-9224-f79233a18457.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
![image](https://user-images.githubusercontent.com/83717836/128712764-e54f046e-6050-4dff-b4e2-d272cd7447b7.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
VIYA:
![image](https://user-images.githubusercontent.com/83717836/128724284-e3942e10-b196-4640-9c55-8559912b66f4.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/128725399-36f5edf0-9626-43e0-9a56-76bd71f8afca.png)
