### PR TITLE
fix: handle context name when it's undefined/null or empty string

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -619,6 +619,11 @@ export default class SASjs {
             authConfig
           )
         } else {
+          if (!config.contextName)
+            config = {
+              ...config,
+              contextName: 'SAS Job Execution compute context'
+            }
           return await this.jesJobExecutor!.execute(
             sasJob,
             data,

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -54,7 +54,12 @@ export class WebJobExecutor extends BaseJobExecutor {
 
       apiUrl += jobUri.length > 0 ? '&_job=' + jobUri : ''
 
-      apiUrl += config.contextName ? `&_contextname=${config.contextName}` : ''
+      // if context name exists and is not blank string
+      // then add _contextname variable in apiUrl
+      apiUrl +=
+        config.contextName && !/\s/.test(config.contextName)
+          ? `&_contextname=${config.contextName}`
+          : ''
     }
 
     let requestParams = {


### PR DESCRIPTION
## Issue

#508

## Intent

- fallback to default context name when passed context name is null/undefined or empty string while useComputeApi is false
- skip _contextname variable from api when passed context name is null/undefined or empty string while useComputeApi is undefined

## Implementation

- added check to see if context name is falsy value then fallback to default while useComputeApi is false
- added check to see if context name is falsy value then skip _contextname variable from apiUrl while useComputeApi is undefined

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/129553560-d9af76f9-5a4f-45ba-a5bb-34c3ee909342.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/129556864-2ae239e6-31de-4aa5-8a9a-0c1fd73fcf71.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
![image](https://user-images.githubusercontent.com/83717836/129547528-d5e73f1c-78bc-48f8-afc5-f818c81af750.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
SAS Viya:
![image](https://user-images.githubusercontent.com/83717836/129554459-e8bb999d-1be4-40f2-bfbb-3b455ba29a59.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/129555232-24905753-dabb-4c09-8515-d9b6a3cdd392.png)
