### PR TITLE
chore: updating .npmignore to reduce bundle size (currently 7.7mb)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 sasjs-tests/
 docs/
 .github/
-CONTRIBUTING.md
+*.md
+*.spec.ts


### PR DESCRIPTION
## Issue

Bundle size on [npmjs](https://www.npmjs.com/package/@sasjs/adapter) is currently 7.72mb

![image](https://user-images.githubusercontent.com/4420615/130289296-8099b02f-9317-492a-b966-b3b8a3c271ba.png)

## Intent

Exclude irrelevant files from NPM build

## Implementation

Updated the .npmignore file.  There could be more to exclude - see the equivalent for the CLI: https://github.com/sasjs/cli/blob/main/.npmignore

## Checks

Checks removed as there were no code changes, but post release we should do immediate checks
