### PR TITLE
chore(deps): pin typescript version to fix packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typedoc": "^0.21.4",
     "typedoc-neo-theme": "^1.1.1",
     "typedoc-plugin-external-module-name": "^4.0.6",
-    "typescript": "^4.3.5",
+    "typescript": "4.3.5",
     "webpack": "^5.44.0",
     "webpack-cli": "^4.7.2"
   },


### PR DESCRIPTION
## Intent

[`typescript 4.4.2`](https://github.com/microsoft/TypeScript/releases/tag/v4.4.2) breaks `package:lib` script.

## Implementation

Pinned `typescript` dependency on version `4.3.5`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/131521736-b56f81f1-47ef-4b25-960c-97428f3b6063.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/131527106-a4a3c134-4d2b-4b03-b716-82b250be1483.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
SAS VIYA:
![image](https://user-images.githubusercontent.com/83717836/131535225-358694e1-7a84-497b-b88e-1ad9dbc4323b.png)
SAS9:

- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
VIYA:
![image](https://user-images.githubusercontent.com/83717836/131533104-8b2cd2cc-7443-483e-8a38-8a7e4ad04ae3.png)
SAS9:
![image](https://user-images.githubusercontent.com/83717836/131533517-0000a9f8-a067-45a4-8efb-185047011a7c.png)
