### PR TITLE
fix: viya debug response null due to wrong content-type

### DIFF
--- a/src/utils/parseViyaDebugResponse.ts
+++ b/src/utils/parseViyaDebugResponse.ts
@@ -25,6 +25,6 @@ export const parseSasViyaDebugResponse = async (
   }
 
   return requestClient
-    .get(serverUrl + jsonUrl, undefined)
+    .get(serverUrl + jsonUrl, undefined, 'text/plain')
     .then((res: any) => getValidJson(res.result))
 }


### PR DESCRIPTION
## Issue

Fixes #554 

## Intent

Fixing viya debug request returning null due to wrong content-type passed in request client.

## Implementation

Added parameter for content-type to be `plain/text`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/133777233-6c333b89-67a0-4951-87d5-aab0e334678a.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/133780605-99302e52-8f65-49b8-b3f9-0c45e1221545.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
![image](https://user-images.githubusercontent.com/18329105/133617134-2d3472c5-1819-4995-a586-fd7905c31781.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
