### PR TITLE
fix: Job executor bugs

### DIFF
--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -78,8 +78,8 @@ export const basicTests = (
           'common/sendArr',
           stringData,
           undefined,
-          () => {
-            adapter.logIn(userName, password)
+          async () => {
+            await adapter.logIn(userName, password)
           }
         )
       },

--- a/src/job-execution/ComputeJobExecutor.ts
+++ b/src/job-execution/ComputeJobExecutor.ts
@@ -45,7 +45,6 @@ export class ComputeJobExecutor extends BaseJobExecutor {
           }
 
           if (e instanceof LoginRequiredError) {
-            await loginCallback()
             this.appendWaitingRequest(() => {
               return this.execute(
                 sasJob,
@@ -61,6 +60,8 @@ export class ComputeJobExecutor extends BaseJobExecutor {
                 }
               )
             })
+
+            await loginCallback()
           } else {
             reject(new ErrorResponse(e?.message, e))
           }

--- a/src/job-execution/JesJobExecutor.ts
+++ b/src/job-execution/JesJobExecutor.ts
@@ -45,8 +45,6 @@ export class JesJobExecutor extends BaseJobExecutor {
           }
 
           if (e instanceof LoginRequiredError) {
-            await loginCallback()
-
             this.appendWaitingRequest(() => {
               return this.execute(
                 sasJob,
@@ -64,6 +62,8 @@ export class JesJobExecutor extends BaseJobExecutor {
                 }
               )
             })
+
+            await loginCallback()
           } else {
             reject(new ErrorResponse(e?.message, e))
           }


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

- append resend requests before making login call
- append resend request for `SASVIYA` when `getJobUri` throw `LoginRequiredError`

What this PR intends to achieve.

## Implementation

 - rearrange the order of execution of `loginCallback` and `appendWaitingRequest`
 - added exception handling for `getJobUri`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/134294229-04ff5224-333d-4d9f-a47a-45955aeda311.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/134347383-02c66584-56d8-4e96-996e-5323a74e38c3.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
SAS Viya:
![image](https://user-images.githubusercontent.com/83717836/134364333-153d98ff-4399-46bc-9262-bc406a1c5b6b.png)
SAS9:
![image](https://user-images.githubusercontent.com/83717836/134365771-fdb5988d-c1df-4f02-a531-ccda8d05085e.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
SAS Viya:
![image](https://user-images.githubusercontent.com/83717836/134358862-906efcfe-4c1e-485e-854d-d03b9d56edf1.png)
SAS9:
![image](https://user-images.githubusercontent.com/83717836/134360120-32752ad4-eb08-47f9-ba02-b4a5a171d1aa.png)