### PR TITLE
fix(job-execution): return Internal Server Error code in case of Stored Process Error

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -627,7 +627,7 @@ const parseError = (data: string) => {
       if (parts.length > 1) {
         const log = parts[1].split('<pre>')[1].split('</pre>')[0]
         const message = `This request completed with errors.`
-        return new JobExecutionError(404, message, log)
+        return new JobExecutionError(500, message, log)
       }
     }
   } catch (_) {}


### PR DESCRIPTION

## Issue

https://github.com/sasjs/cli/issues/1063

## Intent

Return the correct error code when there is a SAS Stored Process Error.

## Implementation

Changed 404 to 500.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
