### PR TITLE
fix: response from SASJS Server with/without debug on

### DIFF
--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -157,11 +157,6 @@ export class WebJobExecutor extends BaseJobExecutor {
 
           let jsonResponse = res.result
 
-          if (this.serverType === ServerType.Sasjs) {
-            const webout = parseWeboutResponse(res.result._webout, apiUrl)
-            jsonResponse = getValidJson(webout)
-          }
-
           if (config.debug) {
             switch (this.serverType) {
               case ServerType.SasViya:
@@ -177,7 +172,13 @@ export class WebJobExecutor extends BaseJobExecutor {
                     ? parseWeboutResponse(res.result, apiUrl)
                     : res.result
                 break
+              case ServerType.Sasjs:
+                const webout = parseWeboutResponse(res.result._webout, apiUrl)
+                jsonResponse = getValidJson(webout)
+                break
             }
+          } else if (this.serverType === ServerType.Sasjs) {
+            jsonResponse = getValidJson(res.result._webout)
           }
 
           const responseObject = appendExtraResponseAttributes(


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

Parsing of response from SASJS server is fine when DEBUG is on but invalid parsing when DEBUG is off.

## Implementation

Added parsing of JSON-String to JSON when DEBUG is off.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
