### PR TITLE
fix(sasjs): restrict usage of localstorage for node env

### DIFF
--- a/src/request/SasjsRequestClient.ts
+++ b/src/request/SasjsRequestClient.ts
@@ -13,7 +13,7 @@ export class SasjsRequestClient extends RequestClient {
 
     headers.Accept = contentType === 'application/json' ? contentType : '*/*'
 
-    if (!accessToken)
+    if (!accessToken && typeof window !== 'undefined')
       accessToken = localStorage.getItem('accessToken') ?? undefined
 
     if (accessToken) headers.Authorization = `Bearer ${accessToken}`


### PR DESCRIPTION
## Issue

no issue to link

## Intent

While `sasjs deploy` it breaks. 
![image](https://user-images.githubusercontent.com/8914650/148212098-76260b8a-cdc4-4e9c-a384-c7fd32c7a0eb.png)


## Implementation

Added check for window.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
