### PR TITLE
feat(executeJobSASjs): add parse _webout in response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/utils": "2.35.0",
-        "axios": "0.25.0",
+        "axios": "0.26.0",
         "axios-cookiejar-support": "2.0.3",
         "form-data": "4.0.0",
         "https": "1.0.0",
@@ -2205,11 +2205,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axios-cookiejar-support": {
@@ -4097,9 +4097,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -14932,11 +14932,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.8"
       }
     },
     "axios-cookiejar-support": {
@@ -16454,9 +16454,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "foreach": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "main": "index.js",
   "dependencies": {
     "@sasjs/utils": "2.35.0",
-    "axios": "0.25.0",
+    "axios": "0.26.0",
     "axios-cookiejar-support": "2.0.3",
     "form-data": "4.0.0",
     "https": "1.0.0",

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -3,6 +3,7 @@ import { RequestClient } from './request/RequestClient'
 import { getAccessTokenForSasjs } from './auth/getAccessTokenForSasjs'
 import { refreshTokensForSasjs } from './auth/refreshTokensForSasjs'
 import { getAuthCodeForSasjs } from './auth/getAuthCodeForSasjs'
+import { parseWeboutResponse } from './utils'
 
 export class SASjsApiClient {
   constructor(
@@ -35,7 +36,12 @@ export class SASjsApiClient {
       log?: string
       logPath?: string
       error?: {}
+      _webout?: string
     }>('SASjsApi/stp/execute', query, undefined)
+
+    if (Object.keys(result).includes('_webout')) {
+      result._webout = parseWeboutResponse(result._webout!)
+    }
 
     return Promise.resolve(result)
   }

--- a/src/types/ExecuteScript.ts
+++ b/src/types/ExecuteScript.ts
@@ -1,4 +1,5 @@
 export interface ExecutionQuery {
   _program: string
   _debug?: number
+  _returnLog?: boolean
 }

--- a/src/types/ExecuteScript.ts
+++ b/src/types/ExecuteScript.ts
@@ -1,5 +1,4 @@
 export interface ExecutionQuery {
   _program: string
   _debug?: number
-  _returnLog?: boolean
 }

--- a/src/utils/parseWeboutResponse.ts
+++ b/src/utils/parseWeboutResponse.ts
@@ -10,6 +10,7 @@ export const parseWeboutResponse = (response: string, url?: string): string => {
         .split('>>weboutEND<<')[0]
     } catch (e) {
       if (url) throw new WeboutResponseError(url)
+
       sasResponse = ''
       console.error(e)
     }


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/1108

## Intent

- Parse `_webout` response.

## Implementation

- Used ` parseWeboutResponse` utility to parse `_webout`.

## Checks

- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
Server(without `request.spec.server`):
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
