### PR TITLE
fix(SASJS): sasjs server deployment with auth + refresh token bug

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -5,9 +5,8 @@ import {
   EditContextInput,
   PollOptions,
   LoginMechanism,
-  FolderMember,
-  ServiceMember,
-  ExecutionQuery
+  ExecutionQuery,
+  FileTree
 } from './types'
 import { SASViyaApiClient } from './SASViyaApiClient'
 import { SAS9ApiClient } from './SAS9ApiClient'
@@ -865,15 +864,22 @@ export default class SASjs {
     )
   }
 
+  /**
+   * Creates the folders and services at the given location `appLoc` on the given server `serverUrl`.
+   * @param members - the JSON specifying the folders and services to be created.
+   * @param appLoc - the base folder in which to create the new folders and
+   * services.  If not provided, is taken from SASjsConfig.
+   * @param authConfig - a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
+   */
   public async deployToSASjs(
-    members: [FolderMember, ServiceMember],
+    members: FileTree,
+    appLoc?: string,
     authConfig?: AuthConfig
   ) {
-    return await this.sasJSApiClient?.deploy(
-      members,
-      this.sasjsConfig.appLoc,
-      authConfig
-    )
+    if (!appLoc) {
+      appLoc = this.sasjsConfig.appLoc
+    }
+    return await this.sasJSApiClient?.deploy(members, appLoc, authConfig)
   }
 
   public async executeJobSASjs(query: ExecutionQuery) {

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -865,8 +865,15 @@ export default class SASjs {
     )
   }
 
-  public async deployToSASjs(members: [FolderMember, ServiceMember]) {
-    return await this.sasJSApiClient?.deploy(members, this.sasjsConfig.appLoc)
+  public async deployToSASjs(
+    members: [FolderMember, ServiceMember],
+    authConfig?: AuthConfig
+  ) {
+    return await this.sasJSApiClient?.deploy(
+      members,
+      this.sasjsConfig.appLoc,
+      authConfig
+    )
   }
 
   public async executeJobSASjs(query: ExecutionQuery) {

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -1,5 +1,5 @@
 import { AuthConfig, ServerType } from '@sasjs/utils/types'
-import { FolderMember, ServiceMember, ExecutionQuery } from './types'
+import { FileTree, ExecutionQuery } from './types'
 import { RequestClient } from './request/RequestClient'
 import { getAccessTokenForSasjs } from './auth/getAccessTokenForSasjs'
 import { refreshTokensForSasjs } from './auth/refreshTokensForSasjs'
@@ -17,7 +17,7 @@ export class SASjsApiClient {
   }
 
   public async deploy(
-    members: [FolderMember, ServiceMember],
+    members: FileTree,
     appLoc: string,
     authConfig?: AuthConfig
   ) {


### PR DESCRIPTION
## Issue

no issue to link

## Intent

Support `SASJS` deployment with authentication

## Implementation

Add AuthConfig as we have for `SASVIYA`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
