### PR TITLE
fix: made pathsasjs non optional in sasjs config

### DIFF
--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -6,6 +6,7 @@ const stringData: any = { table1: [{ col1: 'first col value' }] }
 
 const defaultConfig: SASjsConfig = {
   serverUrl: window.location.origin,
+  pathSASJS: '/SASjsApi/stp/execute',
   pathSAS9: '/SASStoredProcess/do',
   pathSASViya: '/SASJobExecution',
   appLoc: '/Public/seedapp',

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -1018,7 +1018,7 @@ export default class SASjs {
         ? this.sasjsConfig.pathSASViya
         : this.sasjsConfig.serverType === ServerType.Sas9
         ? this.sasjsConfig.pathSAS9
-        : this.sasjsConfig.pathSASJS || ''
+        : this.sasjsConfig.pathSASJS
 
     this.authManager = new AuthManager(
       this.sasjsConfig.serverUrl,

--- a/src/types/SASjsConfig.ts
+++ b/src/types/SASjsConfig.ts
@@ -16,7 +16,7 @@ export class SASjsConfig {
    * The location of the STP Process Web Application.  By default the adapter
    * will use '/SASjsApi/stp/execute' on SAS JS.
    */
-  pathSASJS?: string = ''
+  pathSASJS: string = ''
   /**
    * The location of the Stored Process Web Application.  By default the adapter
    * will use '/SASStoredProcess/do' on SAS 9.


### PR DESCRIPTION
## Issue

none

## Intent

made pathsasjs attribute of  sasjs config non optional (mandatory)

## Implementation

* remove optional symbol from pathSASJS in sasjs config type
* provided default value for pathSASJS

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/153861540-0a71a5cb-17d5-49ca-b793-ccec18b2f6cd.png)
Server (without `request.spec.server.ts`):
![image](https://user-images.githubusercontent.com/83717836/153865339-ef8ddc69-f54b-42af-98e3-d536dad630d2.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
VIYA:
![image](https://user-images.githubusercontent.com/83717836/153868904-ae640d9d-6791-4c9f-8a25-3e4a0117751b.png)
SAS9:
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
Viya:
![image](https://user-images.githubusercontent.com/83717836/153877649-07407e73-ee43-4159-b6c2-28af1d657dd5.png)
SAS9:
![image](https://user-images.githubusercontent.com/83717836/153885673-ff2e549d-d109-42a0-b7e7-e41a4f0ae7f4.png)
