### PR TITLE
fix: reverted axios-cookiejar-support package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@sasjs/utils": "2.35.0",
         "axios": "0.26.0",
-        "axios-cookiejar-support": "2.0.3",
+        "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
         "https": "1.0.0",
         "tough-cookie": "4.0.0"
@@ -1694,8 +1694,7 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
-      "dev": true
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -1981,6 +1980,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1992,6 +1992,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2007,7 +2008,8 @@
     "node_modules/agent-base/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -2213,18 +2215,20 @@
       }
     },
     "node_modules/axios-cookiejar-support": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.3.tgz",
-      "integrity": "sha512-tvMB+0JhxXLjjvePsXzqXhBI4DMlW4ImR4pKKNl+xclwF0IviNV+CkuhubQCCFjPzOXv7PIzOq3z7WFiF9pMpw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
+      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
       "dependencies": {
-        "http-cookie-agent": "^1.0.2"
+        "is-redirect": "^1.0.0",
+        "pify": "^5.0.0"
       },
       "engines": {
-        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+        "node": ">= 10.0.0"
       },
       "peerDependencies": {
-        "axios": ">=0.20.0",
-        "tough-cookie": ">=4.0.0"
+        "@types/tough-cookie": ">=2.3.3",
+        "axios": ">=0.16.2",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "node_modules/babel-jest": {
@@ -4587,20 +4591,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/http-cookie-agent": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.4.tgz",
-      "integrity": "sha512-2gSYSE3m38/QMKPPbbS/6lEIm8OTbGA5sY3aBLtr/BUTNOFNeL4WqkdNQM6WmIBT7AWKC20aYfU3uq+cgR+Byg==",
-      "dependencies": {
-        "agent-base": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
-      },
-      "peerDependencies": {
-        "tough-cookie": "^4.0.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -5147,6 +5137,14 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -10366,6 +10364,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -14501,8 +14510,7 @@
     "@types/tough-cookie": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
-      "dev": true
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -14757,6 +14765,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "requires": {
         "debug": "4"
       },
@@ -14765,6 +14774,7 @@
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
           "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -14772,7 +14782,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -14940,11 +14951,12 @@
       }
     },
     "axios-cookiejar-support": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.3.tgz",
-      "integrity": "sha512-tvMB+0JhxXLjjvePsXzqXhBI4DMlW4ImR4pKKNl+xclwF0IviNV+CkuhubQCCFjPzOXv7PIzOq3z7WFiF9pMpw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
+      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
       "requires": {
-        "http-cookie-agent": "^1.0.2"
+        "is-redirect": "^1.0.0",
+        "pify": "^5.0.0"
       }
     },
     "babel-jest": {
@@ -16803,14 +16815,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "http-cookie-agent": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.4.tgz",
-      "integrity": "sha512-2gSYSE3m38/QMKPPbbS/6lEIm8OTbGA5sY3aBLtr/BUTNOFNeL4WqkdNQM6WmIBT7AWKC20aYfU3uq+cgR+Byg==",
-      "requires": {
-        "agent-base": "^6.0.2"
-      }
-    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -17191,6 +17195,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -21095,6 +21104,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
+    },
+    "pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@sasjs/utils": "2.35.0",
     "axios": "0.26.0",
-    "axios-cookiejar-support": "2.0.3",
+    "axios-cookiejar-support": "1.0.1",
     "form-data": "4.0.0",
     "https": "1.0.0",
     "tough-cookie": "4.0.0"

--- a/src/request/Sas9RequestClient.ts
+++ b/src/request/Sas9RequestClient.ts
@@ -1,6 +1,6 @@
 import * as https from 'https'
 import { AxiosRequestConfig } from 'axios'
-import * as axiosCookieJarSupport from 'axios-cookiejar-support'
+import axiosCookieJarSupport from 'axios-cookiejar-support'
 import * as tough from 'tough-cookie'
 import { prefixMessage } from '@sasjs/utils/error'
 import { RequestClient, throwIfError } from './RequestClient'
@@ -17,7 +17,7 @@ export class Sas9RequestClient extends RequestClient {
       status >= 200 && status < 303
 
     if (axiosCookieJarSupport) {
-      axiosCookieJarSupport.wrapper(this.httpClient)
+      axiosCookieJarSupport(this.httpClient)
       this.httpClient.defaults.jar = new tough.CookieJar()
     }
   }


### PR DESCRIPTION
## Issue

no issue to link

## Intent

Issue with `SAS9` deployment
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/8914650/154392327-dbe282df-17b8-493d-b5c1-82d80c927a4d.png">


## Implementation

Reverted npm package version of `axios-cookiejar-support` and related changes.
Tested with `SAS9` deployment, it works.
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/8914650/154392484-8bd9e3bf-9535-4a41-b37f-4af1bedc896e.png">


## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/154425381-b57d413e-2730-4f84-a26f-fa597f4770f8.png)
Server (without `request.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/154429022-7d5cd445-2833-416c-9e00-0dfd6ee45719.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
Viya:
![image](https://user-images.githubusercontent.com/83717836/154434726-bccc8da3-c2c3-4e63-92d2-2db57c743c7f.png)
SAS 9:
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
Viya:
![image](https://user-images.githubusercontent.com/83717836/154430406-90cb79a1-b7ea-49c9-b3ef-de5af062979f.png)
SAS9:
![image](https://user-images.githubusercontent.com/83717836/154431021-e9a60bdd-dedb-4da0-b46e-2e4c701d1b03.png)