### PR TITLE
fix: no need to parse if webout is an object

### DIFF
--- a/src/job-execution/SasJsJobExecutor.ts
+++ b/src/job-execution/SasJsJobExecutor.ts
@@ -65,8 +65,12 @@ export class SasJsJobExecutor extends BaseJobExecutor {
           let jsonResponse = res.result
 
           if (config.debug) {
-            const webout = parseWeboutResponse(res.result._webout, apiUrl)
-            jsonResponse = getValidJson(webout)
+            if (typeof res.result._webout === 'object') {
+              jsonResponse = res.result._webout
+            } else {
+              const webout = parseWeboutResponse(res.result._webout, apiUrl)
+              jsonResponse = getValidJson(webout)
+            }
           } else {
             jsonResponse = getValidJson(res.result._webout)
           }

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -178,8 +178,12 @@ export class WebJobExecutor extends BaseJobExecutor {
                     : res.result
                 break
               case ServerType.Sasjs:
-                const webout = parseWeboutResponse(res.result._webout, apiUrl)
-                jsonResponse = getValidJson(webout)
+                if (typeof res.result._webout === 'object') {
+                  jsonResponse = res.result._webout
+                } else {
+                  const webout = parseWeboutResponse(res.result._webout, apiUrl)
+                  jsonResponse = getValidJson(webout)
+                }
                 break
             }
           } else if (this.serverType === ServerType.Sasjs) {


### PR DESCRIPTION
## Issue

Related to `SASJS` server, [webout response as json object](https://github.com/sasjs/server/issues/72)

## Intent

Code crashing while parsing json object, trying to extract webout as if it has string headers `>>weboutBEGIN<<`

## Implementation

Added condition not to parse webout, if it's already an object.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
