### PR TITLE
fix: call sasJsJobExecutor only from cli

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -683,7 +683,10 @@ export default class SASjs {
     const validationResult = this.validateInput(data)
 
     if (validationResult.status) {
-      if (config.serverType === ServerType.Sasjs) {
+      if (
+        config.serverType === ServerType.Sasjs &&
+        typeof FormData === 'undefined'
+      ) {
         return await this.sasJsJobExecutor!.execute(
           sasJob,
           data,
@@ -693,7 +696,7 @@ export default class SASjs {
           extraResponseAttributes
         )
       } else if (
-        config.serverType !== ServerType.Sas9 &&
+        config.serverType === ServerType.SasViya &&
         config.useComputeApi !== undefined &&
         config.useComputeApi !== null
       ) {

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -109,6 +109,7 @@ export class WebJobExecutor extends BaseJobExecutor {
     }
 
     // FormData is only valid in browser
+    // FormData is a part of JS web API (not included in native NodeJS).
     let formData = new FormData()
 
     if (data) {

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -108,6 +108,7 @@ export class WebJobExecutor extends BaseJobExecutor {
       ...this.getRequestParams(config)
     }
 
+    // FormData is only valid in browser
     let formData = new FormData()
 
     if (data) {


### PR DESCRIPTION
## Issue

closes #651

## Intent
when server type is sasjs only use sasjs job executor in cli; in browser should use web job executor.

## Implementation

added a check if `typeof FormData === 'undefined'` then it means we are in cli (nodejs). So, use sasjs job executor. 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
