### PR TITLE
fix: utilise utils types for HttpsAgentOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/utils": "2.35.0",
+        "@sasjs/utils": "^2.36.1",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
@@ -1143,23 +1143,50 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.35.0.tgz",
-      "integrity": "sha512-q9ZKV+TXqwiaj+0z5U7/00eBpp2QpjKfC9BKx7A6rQjBl10WtoWd5C9Em+RQULWVEdRbVS2XcnNsWelbKq/Zsw==",
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.1.tgz",
+      "integrity": "sha512-JkGUpLOODsvkeU+S25jb9k2WnvzyD2w6cEk7YyQ/byuqKL8xawH91PPWegrVcJlDY8WmqKE4CPcA3d1mM3B3LA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/fs-extra": "^9.0.13",
-        "@types/prompts": "^2.0.13",
-        "chalk": "^4.1.1",
-        "cli-table": "^0.3.6",
-        "consola": "^2.15.0",
-        "csv-stringify": "^5.6.5",
+        "@types/fs-extra": "9.0.13",
+        "@types/prompts": "2.0.13",
+        "chalk": "4.1.1",
+        "cli-table": "0.3.6",
+        "consola": "2.15.0",
+        "csv-stringify": "5.6.5",
         "find": "0.3.0",
-        "fs-extra": "^10.0.0",
-        "jwt-decode": "^3.1.2",
-        "prompts": "^2.4.1",
-        "rimraf": "^3.0.2",
-        "valid-url": "^1.0.9"
+        "fs-extra": "10.0.0",
+        "jwt-decode": "3.1.2",
+        "prompts": "2.4.1",
+        "rimraf": "3.0.2",
+        "valid-url": "1.0.9"
+      }
+    },
+    "node_modules/@sasjs/utils/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@sasjs/utils/node_modules/prompts": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+      "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -1644,9 +1671,9 @@
       "dev": true
     },
     "node_modules/@types/prompts": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
-      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.13.tgz",
+      "integrity": "sha512-jwMOIGy49VruR/gYehhJYgpVzB+EVpEE7t7j9m1oTo4HMpOe7KmsyqdBuoxAzA5B4caUgx0cKrWr7wUEqMXJ7Q==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2068,6 +2095,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2692,6 +2720,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2762,12 +2791,14 @@
       }
     },
     "node_modules/cli-table": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.9.tgz",
-      "integrity": "sha512-7eA6hFtAZwVx3dWAGoaBqTrzWko5jRUFKpHT64ZHkJpaA3y5wf5NlLjguqTRmqycatJZiwftODYYyGNLbQ7MuA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
+      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
       "dependencies": {
-        "colors": "1.0.3",
-        "strip-ansi": "^6.0.1"
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
       }
     },
     "node_modules/cli-table3": {
@@ -2912,9 +2943,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -10539,6 +10570,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -11685,6 +11717,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -14018,22 +14051,42 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.35.0.tgz",
-      "integrity": "sha512-q9ZKV+TXqwiaj+0z5U7/00eBpp2QpjKfC9BKx7A6rQjBl10WtoWd5C9Em+RQULWVEdRbVS2XcnNsWelbKq/Zsw==",
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.1.tgz",
+      "integrity": "sha512-JkGUpLOODsvkeU+S25jb9k2WnvzyD2w6cEk7YyQ/byuqKL8xawH91PPWegrVcJlDY8WmqKE4CPcA3d1mM3B3LA==",
       "requires": {
-        "@types/fs-extra": "^9.0.13",
-        "@types/prompts": "^2.0.13",
-        "chalk": "^4.1.1",
-        "cli-table": "^0.3.6",
-        "consola": "^2.15.0",
-        "csv-stringify": "^5.6.5",
+        "@types/fs-extra": "9.0.13",
+        "@types/prompts": "2.0.13",
+        "chalk": "4.1.1",
+        "cli-table": "0.3.6",
+        "consola": "2.15.0",
+        "csv-stringify": "5.6.5",
         "find": "0.3.0",
-        "fs-extra": "^10.0.0",
-        "jwt-decode": "^3.1.2",
-        "prompts": "^2.4.1",
-        "rimraf": "^3.0.2",
-        "valid-url": "^1.0.9"
+        "fs-extra": "10.0.0",
+        "jwt-decode": "3.1.2",
+        "prompts": "2.4.1",
+        "rimraf": "3.0.2",
+        "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "prompts": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+          "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.5"
+          }
+        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -14458,9 +14511,9 @@
       "dev": true
     },
     "@types/prompts": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
-      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.13.tgz",
+      "integrity": "sha512-jwMOIGy49VruR/gYehhJYgpVzB+EVpEE7t7j9m1oTo4HMpOe7KmsyqdBuoxAzA5B4caUgx0cKrWr7wUEqMXJ7Q==",
       "requires": {
         "@types/node": "*"
       }
@@ -14828,7 +14881,8 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -15312,6 +15366,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15364,12 +15419,11 @@
       "dev": true
     },
     "cli-table": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.9.tgz",
-      "integrity": "sha512-7eA6hFtAZwVx3dWAGoaBqTrzWko5jRUFKpHT64ZHkJpaA3y5wf5NlLjguqTRmqycatJZiwftODYYyGNLbQ7MuA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
+      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
       "requires": {
-        "colors": "1.0.3",
-        "strip-ansi": "^6.0.1"
+        "colors": "1.0.3"
       }
     },
     "cli-table3": {
@@ -15491,9 +15545,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -21233,6 +21287,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -22135,6 +22190,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@sasjs/utils": "2.35.0",
+    "@sasjs/utils": "2.36.1",
     "axios": "0.26.0",
     "axios-cookiejar-support": "1.0.1",
     "form-data": "4.0.0",

--- a/src/types/SASjsConfig.ts
+++ b/src/types/SASjsConfig.ts
@@ -1,5 +1,6 @@
 import * as https from 'https'
 import { ServerType } from '@sasjs/utils/types'
+import { HttpsAgentOptions } from '@sasjs/utils/types'
 
 /**
  * Specifies the configuration for the SASjs instance - eg where and how to
@@ -64,7 +65,7 @@ export class SASjsConfig {
    * By providing `key`, `cert`, `ca` to connect with server
    * Other options can be set `rejectUnauthorized` and `requestCert`
    */
-  httpsAgentOptions?: https.AgentOptions
+  httpsAgentOptions?: HttpsAgentOptions
   /**
    * Supported login mechanisms are - Redirected and Default
    */


### PR DESCRIPTION
## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/155484062-dba54658-bfd9-4d45-9245-88588e43698f.png)
Server (without `request.spec.server` and `testing.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/155493514-01ce3655-dcb8-48d7-b6fa-3dc72636d316.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
Viya:
![image](https://user-images.githubusercontent.com/83717836/155492050-d8e9491a-bfd4-4068-be59-e5b7c8d0d05d.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/155493313-b9d19c9d-a082-4d7d-99f1-85a39692b5d3.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
Viya:
![image](https://user-images.githubusercontent.com/83717836/155488545-32810b89-baab-4edd-9ded-2c2d8a3a9d1c.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/155489371-c39b5301-648b-44b6-9b44-6c0d83bd8003.png)