### PR TITLE
fix: changed return code in case of job execution error

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -635,7 +635,7 @@ const parseError = (data: string) => {
       if (parts.length > 1) {
         const storedProcessPath = parts[1].split('<i>')[1].split('</i>')[0]
         const message = `Stored process not found: ${storedProcessPath}`
-        return new JobExecutionError(404, message, '')
+        return new JobExecutionError(500, message, '')
       }
     }
   } catch (_) {}
@@ -649,7 +649,7 @@ const parseError = (data: string) => {
       if (parts.length > 1) {
         const log = parts[1].split('<pre>')[1].split('</pre>')[0]
         const message = `This request completed with errors.`
-        return new JobExecutionError(404, message, log)
+        return new JobExecutionError(500, message, log)
       }
     }
   } catch (_) {}


### PR DESCRIPTION
## Issue

no issue to link.

## Intent

If `SAS9` deploy fails with error of type `jobExecutionError`. it throws `404` as errorCode to `sasjs/cli`.
And sasjs/cli deals `404` as sasjs_runner issue.


## Implementation

Setting `500` instead of `404` while throwing error.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/155527422-32b85222-34b9-4451-9286-245a6fd04169.png)
Server (without `request.spec.server` and `testing.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/155535702-03b46c84-cd32-4577-a7e7-acfc81556971.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
Viya:
![image](https://user-images.githubusercontent.com/83717836/155535538-6f7c3c6f-a07c-4c4c-b5d8-157c93bf73a6.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/155536817-0ae3dd49-16fd-44dd-9f2a-452dc0fe67eb.png)
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
Viya:
![image](https://user-images.githubusercontent.com/83717836/155532558-ee33321d-298e-42f3-8e88-b58eac4d4041.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/155532948-1224f0b3-749c-4b77-9e2b-71d922c20a1e.png)