### PR TITLE
fix: WebJobExecutor also returns log along result

### DIFF
--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -208,7 +208,7 @@ export class WebJobExecutor extends BaseJobExecutor {
           }
 
           const responseObject = appendExtraResponseAttributes(
-            { result: jsonResponse },
+            { result: jsonResponse, log: parsedSasjsServerLog },
             extraResponseAttributes
           )
           resolve(responseObject)


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

Why not returning `log` in response object, `WebJobExecutor`

## Implementation

Added log attribute to return object for `WebJobExecutor`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/155683848-62ce50f1-5845-497a-9908-585caa17b81f.png)
Server (without `testing.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/155691776-06dab289-8ac9-4441-bcd5-2d3828e1ed25.png)
- [x] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
VIYA:
![image](https://user-images.githubusercontent.com/83717836/155687393-e88e0654-a95d-42ad-9abb-f69f1a03efcf.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/155689069-9a66242c-66dd-4397-951c-133d0af16154.png)
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
Viya:
![image](https://user-images.githubusercontent.com/83717836/155694693-f0cc36d5-7e2b-4695-adf1-b30b43aa2ae0.png)
SAS 9: