### PR TITLE
fix(viya): updated getAccessTokenForViya with headers based on latest docs

### DIFF
--- a/src/auth/getAccessTokenForViya.ts
+++ b/src/auth/getAccessTokenForViya.ts
@@ -1,6 +1,5 @@
 import { SasAuthResponse } from '@sasjs/utils/types'
 import { prefixMessage } from '@sasjs/utils/error'
-import * as NodeFormData from 'form-data'
 import { RequestClient } from '../request/RequestClient'
 
 /**
@@ -24,26 +23,17 @@ export async function getAccessTokenForViya(
     token = Buffer.from(clientId + ':' + clientSecret).toString('base64')
   }
   const headers = {
-    Authorization: 'Basic ' + token
+    Authorization: 'Basic ' + token,
+    Accept: 'application/json'
   }
 
-  let formData
-  if (typeof FormData === 'undefined') {
-    formData = new NodeFormData()
-  } else {
-    formData = new FormData()
-  }
-  formData.append('grant_type', 'authorization_code')
-  formData.append('code', authCode)
+  const data = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: authCode
+  })
 
   const authResponse = await requestClient
-    .post(
-      url,
-      formData,
-      undefined,
-      'multipart/form-data; boundary=' + (formData as any)._boundary,
-      headers
-    )
+    .post(url, data, undefined, 'application/x-www-form-urlencoded', headers)
     .then((res) => res.result as SasAuthResponse)
     .catch((err) => {
       throw prefixMessage(err, 'Error while getting access token. ')

--- a/src/auth/spec/getAccessTokenForViya.spec.ts
+++ b/src/auth/spec/getAccessTokenForViya.spec.ts
@@ -35,11 +35,12 @@ describe('getAccessTokenForViya', () => {
 
     expect(requestClient.post).toHaveBeenCalledWith(
       '/SASLogon/oauth/token',
-      expect.any(NodeFormData),
+      expect.any(URLSearchParams),
       undefined,
-      expect.stringContaining('multipart/form-data; boundary='),
+      'application/x-www-form-urlencoded',
       {
-        Authorization: 'Basic ' + token
+        Authorization: 'Basic ' + token,
+        Accept: 'application/json'
       }
     )
   })


### PR DESCRIPTION
## Issue

Fixes #660 

## Intent

Unable to perform `sasjs auth` (exchange of authCode with accessToken/refreshToken) on SASVIYA4

## Implementation

Implemented request with headers based on SASVIYA4 docs.

It also works with SASVIYA3.5:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/8914650/156171764-25641ae2-3536-4e1c-8fab-7b5b469d6a92.png">


## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
