### PR TITLE
fix: raising error with details we get from server

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -557,8 +557,18 @@ export class RequestClient implements HttpClient {
 }
 
 export const throwIfError = (response: AxiosResponse) => {
-  if (response.status === 401) {
-    throw new LoginRequiredError()
+  switch (response.status) {
+    case 400:
+      if (typeof response.data === 'object') {
+        throw new LoginRequiredError(response.data)
+      }
+      break
+    case 401:
+      if (typeof response.data === 'object') {
+        throw new LoginRequiredError(response.data)
+      } else {
+        throw new LoginRequiredError()
+      }
   }
 
   if (response.data?.entityID?.includes('login')) {

--- a/src/types/errors/LoginRequiredError.ts
+++ b/src/types/errors/LoginRequiredError.ts
@@ -1,6 +1,10 @@
 export class LoginRequiredError extends Error {
-  constructor() {
-    super('Auth error: You must be logged in to access this resource')
+  constructor(details?: any) {
+    const message = details
+      ? JSON.stringify(details, null, 2)
+      : 'You must be logged in to access this resource'
+
+    super(`Auth error: ${message}`)
     this.name = 'LoginRequiredError'
     Object.setPrototypeOf(this, LoginRequiredError.prototype)
   }


### PR DESCRIPTION
## Issue

no issue to link.

## Intent

Should provide some details and not always show loginRequiredError for exchanging authCode with access/refresh tokens

## Implementation

What code changes have been made to achieve the intent.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
