### PR TITLE
fix: Viya 4 provides incorrect memberCount in the folders API

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -836,7 +836,9 @@ export class SASViyaApiClient {
 
     const { result: members } = await this.requestClient
       .get<{ items: any[] }>(
-        `/folders/folders/${folder.id}/members?limit=${folder.memberCount}`,
+        `/folders/folders/${folder.id}/members?limit=${
+          folder.memberCount < 500 ? 500 : folder.memberCount
+        }`, // this is temporary fix for https://github.com/sasjs/adapter/issues/669
         accessToken
       )
       .catch((err) => {

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -838,7 +838,7 @@ export class SASViyaApiClient {
       .get<{ items: any[] }>(
         `/folders/folders/${folder.id}/members?limit=${
           folder.memberCount < 500 ? 500 : folder.memberCount
-        }`, // this is temporary fix for https://github.com/sasjs/adapter/issues/669
+        }`, // this is a fix for https://github.com/sasjs/adapter/issues/669
         accessToken
       )
       .catch((err) => {


### PR DESCRIPTION
## Issue

closes #669 

## Intent

* As Viya4 provides an incorrect member count, so we set a minimum limit to 500
## Implementation

* if `memberCount` in folder is less than 500 then set limit to 500 else go with `folder.memberCount`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
