### PR TITLE
fix: fallback to contextName from sasjs config if provided…

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -113,6 +113,9 @@ export default class SASjs {
     debug?: boolean
   ) {
     this.isMethodSupported('executeScriptSASViya', [ServerType.SasViya])
+    
+    contextName = contextName || this.sasjsConfig.contextName
+
     if (!contextName) {
       throw new Error(
         'Context name is undefined. Please set a `contextName` in your SASjs or override config.'

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -113,7 +113,7 @@ export default class SASjs {
     debug?: boolean
   ) {
     this.isMethodSupported('executeScriptSASViya', [ServerType.SasViya])
-    
+
     contextName = contextName || this.sasjsConfig.contextName
 
     if (!contextName) {


### PR DESCRIPTION
… contextName is empty

closes #672 

## Intent

* if provided `contextName` in `executeScriptSASViya` method is empty (falsey value) then we should fallback to contextName from sasjsConfig.

## Implementation

* `contextName = contextName || this.sasjsConfig.contextName` 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
