### PR TITLE
fix: no need to stringify res/err in sas9JobExecutor before appending…

### DIFF
--- a/src/job-execution/Sas9JobExecutor.ts
+++ b/src/job-execution/Sas9JobExecutor.ts
@@ -85,10 +85,12 @@ export class Sas9JobExecutor extends BaseJobExecutor {
       }
     )
       .then((res: any) => {
+        //appending response to requests array that will be used for requests history reference
         this.requestClient!.appendRequest(res, sasJob, config.debug)
         return res
       })
       .catch((err: any) => {
+        //appending error to requests array that will be used for requests history reference
         this.requestClient!.appendRequest(err, sasJob, config.debug)
         return err
       })

--- a/src/job-execution/Sas9JobExecutor.ts
+++ b/src/job-execution/Sas9JobExecutor.ts
@@ -85,25 +85,11 @@ export class Sas9JobExecutor extends BaseJobExecutor {
       }
     )
       .then((res: any) => {
-        let resString = res
-
-        if (typeof res === 'object') {
-          resString = JSON.stringify(res)
-        }
-
-        this.requestClient!.appendRequest(resString, sasJob, config.debug)
-
+        this.requestClient!.appendRequest(res, sasJob, config.debug)
         return res
       })
       .catch((err: any) => {
-        let errString = err
-
-        if (typeof err === 'object') {
-          errString = JSON.stringify(errString)
-        }
-
-        this.requestClient!.appendRequest(errString, sasJob, config.debug)
-
+        this.requestClient!.appendRequest(err, sasJob, config.debug)
         return err
       })
   }


### PR DESCRIPTION
… request #675

## Issue

closes #675 

## Intent

remove the stringification of res/err before appending requests for history

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
