### PR TITLE
feat(deploy): stream app deployment on SASJS server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/utils": "2.36.1",
+        "@sasjs/utils": "2.40.0",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.1.tgz",
-      "integrity": "sha512-JkGUpLOODsvkeU+S25jb9k2WnvzyD2w6cEk7YyQ/byuqKL8xawH91PPWegrVcJlDY8WmqKE4CPcA3d1mM3B3LA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.40.0.tgz",
+      "integrity": "sha512-U0y/eqRlvfkMHmKDlr1xmeN+Rask7TnJPuRpOz71P8QpGYTw1M9AyZvzRSk503p4KCJb8ysdcqXyGVLfhuoM+A==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -13870,9 +13870,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.1.tgz",
-      "integrity": "sha512-JkGUpLOODsvkeU+S25jb9k2WnvzyD2w6cEk7YyQ/byuqKL8xawH91PPWegrVcJlDY8WmqKE4CPcA3d1mM3B3LA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.40.0.tgz",
+      "integrity": "sha512-U0y/eqRlvfkMHmKDlr1xmeN+Rask7TnJPuRpOz71P8QpGYTw1M9AyZvzRSk503p4KCJb8ysdcqXyGVLfhuoM+A==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@sasjs/utils": "2.36.1",
+    "@sasjs/utils": "2.40.0",
     "axios": "0.26.0",
     "axios-cookiejar-support": "1.0.1",
     "form-data": "4.0.0",

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -135,7 +135,7 @@ export default class SASjs {
 
   /**
    * Gets compute contexts.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async getComputeContexts(accessToken: string) {
     this.isMethodSupported('getComputeContexts', [ServerType.SasViya])
@@ -145,7 +145,7 @@ export default class SASjs {
 
   /**
    * Gets launcher contexts.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async getLauncherContexts(accessToken: string) {
     this.isMethodSupported('getLauncherContexts', [ServerType.SasViya])
@@ -164,7 +164,7 @@ export default class SASjs {
 
   /**
    * Gets executable compute contexts.
-   * @param authConfig - an access token, refresh token, client and secret for an authorized user.
+   * @param authConfig - an access token, refresh token, client and secret for an authorised user.
    */
   public async getExecutableContexts(authConfig: AuthConfig) {
     this.isMethodSupported('getExecutableContexts', [ServerType.SasViya])
@@ -178,8 +178,8 @@ export default class SASjs {
    * @param launchContextName - the name of the launcher context used by the compute service.
    * @param sharedAccountId - the ID of the account to run the servers for this context as.
    * @param autoExecLines - the lines of code to execute during session initialization.
-   * @param accessToken - an access token for an authorized user.
-   * @param authorizedUsers - an optional list of authorized user IDs.
+   * @param accessToken - an access token for an authorised user.
+   * @param authorisedUsers - an optional list of authorised user IDs.
    */
   public async createComputeContext(
     contextName: string,
@@ -187,7 +187,7 @@ export default class SASjs {
     sharedAccountId: string,
     autoExecLines: string[],
     accessToken: string,
-    authorizedUsers?: string[]
+    authorisedUsers?: string[]
   ) {
     this.isMethodSupported('createComputeContext', [ServerType.SasViya])
 
@@ -197,7 +197,7 @@ export default class SASjs {
       sharedAccountId,
       autoExecLines,
       accessToken,
-      authorizedUsers
+      authorisedUsers
     )
   }
 
@@ -206,7 +206,7 @@ export default class SASjs {
    * @param contextName - the name of the context to be created.
    * @param description - the description of the context to be created.
    * @param launchType - launch type of the context to be created.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async createLauncherContext(
     contextName: string,
@@ -228,7 +228,7 @@ export default class SASjs {
    * Updates a compute context on the given server.
    * @param contextName - the original name of the context to be deleted.
    * @param editedContext - an object with the properties to be updated.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async editComputeContext(
     contextName: string,
@@ -247,7 +247,7 @@ export default class SASjs {
   /**
    * Deletes a compute context on the given server.
    * @param contextName - the name of the context to be deleted.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async deleteComputeContext(contextName: string, accessToken?: string) {
     this.isMethodSupported('deleteComputeContext', [ServerType.SasViya])
@@ -262,7 +262,7 @@ export default class SASjs {
    * Returns a JSON representation of a compute context.
    * @example: { "createdBy": "admin", "links": [...], "id": "ID", "version": 2, "name": "context1" }
    * @param contextName - the name of the context to return.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async getComputeContextByName(
     contextName: string,
@@ -279,7 +279,7 @@ export default class SASjs {
   /**
    * Returns a JSON representation of a compute context.
    * @param contextId - an id of the context to return.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async getComputeContextById(contextId: string, accessToken?: string) {
     this.isMethodSupported('getComputeContextById', [ServerType.SasViya])
@@ -893,7 +893,7 @@ export default class SASjs {
    * @param appLoc - the base folder in which to create the new folders and
    * services.  If not provided, is taken from SASjsConfig.
    * @param streamConfig - optional configuration object of StreamConfig for deploying streaming app.
-   * @param authConfig - a valid client, secret, refresh and access tokens that are authorized to execute compute jobs.
+   * @param authConfig - a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
    */
   public async deployToSASjs(
     members: FileTree,
@@ -927,7 +927,7 @@ export default class SASjs {
    * @param config - provide any changes to the config here, for instance to
    * enable/disable `debug`. Any change provided will override the global config,
    * for that particular function call.
-   * @param authConfig - a valid client, secret, refresh and access tokens that are authorized to execute compute jobs.
+   * @param authConfig - a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
    * The access token is not required when the user is authenticated via the browser.
    * @param waitForResult - a boolean that indicates whether the function needs to wait for execution to complete.
    * @param pollOptions - an object that represents poll interval(milliseconds) and maximum amount of attempts. Object example: { MAX_POLL_COUNT: 24 * 60 * 60, POLL_INTERVAL: 1000 }.
@@ -980,7 +980,7 @@ export default class SASjs {
   /**
    * Fetches content of the log file
    * @param logUrl - url of the log file.
-   * @param accessToken - an access token for an authorized user.
+   * @param accessToken - an access token for an authorised user.
    */
   public async fetchLogFileContent(logUrl: string, accessToken?: string) {
     return await this.requestClient!.get(logUrl, accessToken).then((res) => {

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -17,7 +17,8 @@ import {
   MacroVar,
   AuthConfig,
   ExtraResponseAttributes,
-  SasAuthResponse
+  SasAuthResponse,
+  StreamConfig
 } from '@sasjs/utils/types'
 import { RequestClient } from './request/RequestClient'
 import { SasjsRequestClient } from './request/SasjsRequestClient'
@@ -891,17 +892,24 @@ export default class SASjs {
    * @param members - the JSON specifying the folders and services to be created.
    * @param appLoc - the base folder in which to create the new folders and
    * services.  If not provided, is taken from SASjsConfig.
-   * @param authConfig - a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
+   * @param streamConfig - optional configuration object of StreamConfig for deploying streaming app.
+   * @param authConfig - a valid client, secret, refresh and access tokens that are authorized to execute compute jobs.
    */
   public async deployToSASjs(
     members: FileTree,
     appLoc?: string,
+    streamConfig?: StreamConfig,
     authConfig?: AuthConfig
   ) {
     if (!appLoc) {
       appLoc = this.sasjsConfig.appLoc
     }
-    return await this.sasJSApiClient?.deploy(members, appLoc, authConfig)
+    return await this.sasJSApiClient?.deploy(
+      members,
+      appLoc,
+      streamConfig,
+      authConfig
+    )
   }
 
   public async executeJobSASjs(query: ExecutionQuery) {
@@ -919,7 +927,7 @@ export default class SASjs {
    * @param config - provide any changes to the config here, for instance to
    * enable/disable `debug`. Any change provided will override the global config,
    * for that particular function call.
-   * @param authConfig - a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
+   * @param authConfig - a valid client, secret, refresh and access tokens that are authorized to execute compute jobs.
    * The access token is not required when the user is authenticated via the browser.
    * @param waitForResult - a boolean that indicates whether the function needs to wait for execution to complete.
    * @param pollOptions - an object that represents poll interval(milliseconds) and maximum amount of attempts. Object example: { MAX_POLL_COUNT: 24 * 60 * 60, POLL_INTERVAL: 1000 }.

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -34,6 +34,7 @@ export class SASjsApiClient {
     const { result } = await this.requestClient.post<{
       status: string
       message: string
+      streamServiceName?: string
       example?: {}
     }>(
       'SASjsApi/drive/deploy',

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -1,4 +1,4 @@
-import { AuthConfig, ServerType } from '@sasjs/utils/types'
+import { AuthConfig, ServerType, StreamConfig } from '@sasjs/utils/types'
 import { FileTree, ExecutionQuery } from './types'
 import { RequestClient } from './request/RequestClient'
 import { getAccessTokenForSasjs } from './auth/getAccessTokenForSasjs'
@@ -20,6 +20,7 @@ export class SASjsApiClient {
   public async deploy(
     members: FileTree,
     appLoc: string,
+    streamConfig?: StreamConfig,
     authConfig?: AuthConfig
   ) {
     let access_token = (authConfig || {}).access_token
@@ -36,7 +37,13 @@ export class SASjsApiClient {
       example?: {}
     }>(
       'SASjsApi/drive/deploy',
-      { fileTree: members, appLoc: appLoc },
+      {
+        fileTree: members,
+        appLoc: appLoc,
+        streamServiceName: streamConfig?.streamServiceName,
+        streamWebFolder: streamConfig?.streamWebFolder,
+        streamLogo: streamConfig?.streamLogo
+      },
       access_token,
       undefined,
       {},


### PR DESCRIPTION
## Issue

sasjs/server [issue](https://github.com/sasjs/server/issues/91)

## Intent

Add stream app related info(streamServiceName, streamWebFolder, streamLogo) in deploy request.

## Implementation

Deploy request to `SASJS` server contains additional body param from `StreamConfig`.
- streamWebFolder
- streamServiceName OPTIONAL <-- server can auto-assign name OR in case of conflict with existing
- streamLogo OPTIONAL <-- server can auto-assign logo

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
