### PR TITLE
fix: blob is not defined

### DIFF
--- a/src/file/generateFileUploadForm.ts
+++ b/src/file/generateFileUploadForm.ts
@@ -26,11 +26,18 @@ export const generateFileUploadForm = (
       )
     }
 
-    const file = new Blob([csv], {
-      type: 'application/csv'
-    })
+    if (typeof FormData === 'undefined' && formData instanceof NodeFormData) {
+      formData.append(name, csv, {
+        filename: `${name}.csv`,
+        contentType: 'application/csv'
+      })
+    } else {
+      const file = new Blob([csv], {
+        type: 'application/csv'
+      })
 
-    formData.append(name, file, `${name}.csv`)
+      formData.append(name, file, `${name}.csv`)
+    }
   }
 
   return formData


### PR DESCRIPTION
## Issue

closes #684 

## Intent

- fix "blob is not defined" in node. This error was occurring in `generateFileUploadForm` function when running in cli.

## Implementation

- remove the creation of blob in cli
- directly append the generated csv string in formData in cli

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/159913715-da75d955-7bd0-41ad-a472-0927c14a33ad.png)
Server (without `request.spec.server`:
![image](https://user-images.githubusercontent.com/83717836/159921302-2a06301f-396d-4843-bf83-b1fc5f85c020.png)
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
VIYA:
![image](https://user-images.githubusercontent.com/83717836/159916321-cc6ba612-227a-4085-ab41-a252ea88d5de.png)
SAS 9:
![image](https://user-images.githubusercontent.com/83717836/159916988-46003ed5-8abb-43a5-899d-2b7e052354c4.png)