### PR TITLE
fix: update code for extracting JSON URL on viya4 when debug is enabled

### DIFF
--- a/src/utils/parseViyaDebugResponse.ts
+++ b/src/utils/parseViyaDebugResponse.ts
@@ -16,10 +16,15 @@ export const parseSasViyaDebugResponse = async (
   requestClient: RequestClient,
   serverUrl: string
 ) => {
+  // On viya 3.5, iframe is like <iframe style="width: 99%; height: 500px" src="..."></iframe>
+  // On viya 4, iframe is like <iframe style="width: 99%; height: 500px; background-color:Canvas;" src=...></iframe>
+
   const iframeStart = response.split(
-    '<iframe style="width: 99%; height: 500px" src="'
+    /<iframe style="width: 99%; height: 500px" src="|<iframe style="width: 99%; height: 500px; background-color:Canvas;" src=/
   )[1]
-  const jsonUrl = iframeStart ? iframeStart.split('"></iframe>')[0] : null
+  const jsonUrl = iframeStart
+    ? iframeStart.split(/"><\/iframe>|><\/iframe>/)[0]
+    : null
   if (!jsonUrl) {
     throw new Error('Unable to find webout file URL.')
   }


### PR DESCRIPTION
## Issue

closes #689 

## Intent

- viya4 returns a bit different iframe than viya 3.5. Adjusted the code to handle both cases.

## Implementation

- used regex instead of simple string to extract JSON URL from the iframe element.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
