### PR TITLE
feat: add method for executing scripts on sasjs server

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -98,6 +98,17 @@ export default class SASjs {
   }
 
   /**
+   * Executes code against a SAS JS server
+   * @param code - a string of code from the file to run.
+   * @param authConfig - (optional) a valid client, secret, refresh and access tokens that are authorised to execute scripts.
+   */
+  public async executeScriptSASjs(code: string, authConfig?: AuthConfig) {
+    this.isMethodSupported('executeScriptSASJS', [ServerType.Sasjs])
+
+    return await this.sasJSApiClient?.executeScript(code, authConfig)
+  }
+
+  /**
    * Executes sas code in a SAS Viya compute session.
    * @param fileName - name of the file to run. It will be converted to path to the file being submitted for execution.
    * @param linesOfCode - lines of sas code from the file to run.

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -77,7 +77,7 @@ export default class SASjs {
   }
 
   /**
-   * Executes code against a SAS 9 server.  Requires a runner to be present in
+   * Executes SAS code on a SAS 9 server.  Requires a runner to be present in
    * the users home directory in metadata.
    * @param linesOfCode - lines of sas code from the file to run.
    * @param username - a string representing the username.
@@ -98,7 +98,7 @@ export default class SASjs {
   }
 
   /**
-   * Executes code against a SAS JS server
+   * Executes SAS code on a SASJS server
    * @param code - a string of code from the file to run.
    * @param authConfig - (optional) a valid client, secret, refresh and access tokens that are authorised to execute scripts.
    */

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -61,6 +61,28 @@ export class SASjsApiClient {
   }
 
   /**
+   * Executes code on a SASJS server.
+   * @param serverUrl - a server url to execute code.
+   * @param code - a string of code to execute.
+   */
+  public async executeScript(code: string, authConfig?: AuthConfig) {
+    let access_token = (authConfig || {}).access_token
+    if (authConfig) {
+      ;({ access_token } = await getTokens(
+        this.requestClient,
+        authConfig,
+        ServerType.Sasjs
+      ))
+    }
+    const response = await this.requestClient.post(
+      'SASjsApi/code/execute',
+      { code },
+      access_token
+    )
+    return response.result as string
+  }
+
+  /**
    * Exchanges the auth code for an access token for the given client.
    * @param clientId - the client ID to authenticate with.
    * @param authCode - the auth code received from the server.


### PR DESCRIPTION
## Issue

none

## Intent

* execute script on sasjs server

## Implementation

* add a method `executeScript` in `SASjsApiClient` class for executing scripts on sasjs server 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
