### PR TITLE
fix: parse log in executeScript method on sasjs server

### DIFF
--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -62,8 +62,8 @@ export class SASjsApiClient {
 
   /**
    * Executes code on a SASJS server.
-   * @param serverUrl - a server url to execute code.
    * @param code - a string of code to execute.
+   * @param authConfig - an object for authentication.
    */
   public async executeScript(code: string, authConfig?: AuthConfig) {
     let access_token = (authConfig || {}).access_token

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -80,9 +80,11 @@ export class SASjsApiClient {
     await this.requestClient
       .post('SASjsApi/code/execute', { code }, access_token)
       .then((res: any) => {
-        parsedSasjsServerLog = res.result.log
-          .map((logLine: any) => logLine.line)
-          .join('\n')
+        if (res.result?.log) {
+          parsedSasjsServerLog = res.result.log
+            .map((logLine: any) => logLine.line)
+            .join('\n')
+        }
       })
       .catch((err) => {
         parsedSasjsServerLog = err

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -74,12 +74,21 @@ export class SASjsApiClient {
         ServerType.Sasjs
       ))
     }
-    const response = await this.requestClient.post(
-      'SASjsApi/code/execute',
-      { code },
-      access_token
-    )
-    return response.result as string
+
+    let parsedSasjsServerLog = ''
+
+    await this.requestClient
+      .post('SASjsApi/code/execute', { code }, access_token)
+      .then((res: any) => {
+        parsedSasjsServerLog = res.result.log
+          .map((logLine: any) => logLine.line)
+          .join('\n')
+      })
+      .catch((err) => {
+        parsedSasjsServerLog = err
+      })
+
+    return parsedSasjsServerLog
   }
 
   /**


### PR DESCRIPTION
## Issue

* we get log in the form of the array when the script is executed on sasjs server

## Intent

* parse the log to make it a single string



## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
