### PR TITLE
sasjs server type - request and job execution auth fix

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -916,8 +916,8 @@ export default class SASjs {
     return await this.sasJSApiClient?.deploy(dataJson, appLoc, authConfig)
   }
 
-  public async executeJobSASjs(query: ExecutionQuery) {
-    return await this.sasJSApiClient?.executeJob(query)
+  public async executeJobSASjs(query: ExecutionQuery, authConfig?: AuthConfig) {
+    return await this.sasJSApiClient?.executeJob(query, authConfig)
   }
 
   /**

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -43,7 +43,9 @@ export class SASjsApiClient {
     return Promise.resolve(result)
   }
 
-  public async executeJob(query: ExecutionQuery) {
+  public async executeJob(query: ExecutionQuery, authConfig?: AuthConfig) {
+    const access_token = authConfig ? authConfig.access_token : undefined
+
     const { result } = await this.requestClient.post<{
       status: string
       message: string
@@ -51,7 +53,7 @@ export class SASjsApiClient {
       logPath?: string
       error?: {}
       _webout?: string
-    }>('SASjsApi/stp/execute', query, undefined)
+    }>('SASjsApi/stp/execute', query, access_token)
 
     if (Object.keys(result).includes('_webout')) {
       result._webout = parseWeboutResponse(result._webout!)

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -229,7 +229,7 @@ export class WebJobExecutor extends BaseJobExecutor {
                 )
               )
             }
-            
+
             this.appendWaitingRequest(() => {
               return this.execute(
                 sasJob,


### PR DESCRIPTION
## Issue

#703 

## Intent

When using adapter with Sasjs server type:
- `executeJob` function was missing `authConfig` parameter.
- `request` method wasn't returning error when access token missing - because we use web approach which was waiting on loggin to resend request. Now if callback is not present we don't engage resend requests, we abort execution and return error.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/165548136-13274740-317b-4f64-a1ee-9bc25231078c.png)
Server:
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
