### PR TITLE
ClientID when login to SASJS server deprecation

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -598,7 +598,7 @@ export default class SASjs {
             'A username, password and clientId are required when using the default login mechanism with server type SASJS.'
           )
 
-        return this.authManager!.logInSasjs(username, password, clientId)
+        return this.authManager!.logInSasjs(username, password)
       }
 
       return this.authManager!.logIn(username, password)

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -104,7 +104,7 @@ export class SASjsApiClient {
     clientId: string,
     authCode: string
   ): Promise<SASjsAuthResponse> {
-    return getAccessTokenForSasjs(this.requestClient, clientId, authCode)
+    return getAccessTokenForSasjs(this.requestClient, authCode)
   }
 
   /**
@@ -126,7 +126,7 @@ export class SASjsApiClient {
     password: string,
     clientId: string
   ) {
-    return getAuthCodeForSasjs(this.requestClient, username, password, clientId)
+    return getAuthCodeForSasjs(this.requestClient, username, password)
   }
 }
 

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -92,14 +92,9 @@ export class AuthManager {
    */
   public async logInSasjs(
     username: string,
-    password: string,
-    clientId: string
+    password: string
   ): Promise<LoginResult> {
-    const isLoggedIn = await this.sendLoginRequestSasjs(
-      username,
-      password,
-      clientId
-    )
+    const isLoggedIn = await this.sendLoginRequestSasjs(username, password)
       .then((res) => {
         this.userName = username
         this.requestClient.saveLocalStorageToken(
@@ -215,18 +210,13 @@ export class AuthManager {
     return loginResponse
   }
 
-  private async sendLoginRequestSasjs(
-    username: string,
-    password: string,
-    clientId: string
-  ) {
+  private async sendLoginRequestSasjs(username: string, password: string) {
     const authCode = await getAuthCodeForSasjs(
       this.requestClient,
       username,
-      password,
-      clientId
+      password
     )
-    return getAccessTokenForSasjs(this.requestClient, clientId, authCode)
+    return getAccessTokenForSasjs(this.requestClient, authCode)
   }
   /**
    * Checks whether a session is active, or login is required.

--- a/src/auth/getAccessTokenForSasjs.ts
+++ b/src/auth/getAccessTokenForSasjs.ts
@@ -9,12 +9,10 @@ import { RequestClient } from '../request/RequestClient'
  */
 export async function getAccessTokenForSasjs(
   requestClient: RequestClient,
-  clientId: string,
   authCode: string
 ) {
   const url = '/SASjsApi/auth/token'
   const data = {
-    clientId,
     code: authCode
   }
 

--- a/src/auth/getAuthCodeForSasjs.ts
+++ b/src/auth/getAuthCodeForSasjs.ts
@@ -11,11 +11,10 @@ import { RequestClient } from '../request/RequestClient'
 export const getAuthCodeForSasjs = async (
   requestClient: RequestClient,
   username: string,
-  password: string,
-  clientId: string
+  password: string
 ) => {
   const url = '/SASjsApi/auth/authorize'
-  const data = { username, password, clientId }
+  const data = { username, password }
 
   const { code: authCode } = await requestClient
     .post<{ code: string }>(url, data, undefined)

--- a/src/auth/spec/getAccessTokenForSasjs.spec.ts
+++ b/src/auth/spec/getAccessTokenForSasjs.spec.ts
@@ -22,15 +22,11 @@ describe('getAccessTokenForSasjs', () => {
         Promise.resolve({ result: mockSasjsAuthResponse, etag: '' })
       )
 
-    await getAccessTokenForSasjs(
-      requestClient,
-      authConfig.client,
-      authConfig.refresh_token
-    )
+    await getAccessTokenForSasjs(requestClient, authConfig.refresh_token)
 
     expect(requestClient.post).toHaveBeenCalledWith(
       '/SASjsApi/auth/token',
-      { clientId: authConfig.client, code: authConfig.refresh_token },
+      { code: authConfig.refresh_token },
       undefined
     )
   })
@@ -51,7 +47,6 @@ describe('getAccessTokenForSasjs', () => {
 
     const error = await getAccessTokenForSasjs(
       requestClient,
-      authConfig.client,
       authConfig.refresh_token
     ).catch((e) => e)
 

--- a/src/utils/convertToCsv.ts
+++ b/src/utils/convertToCsv.ts
@@ -1,4 +1,4 @@
-import { isSpecialMissing } from '@sasjs/utils'
+import { isSpecialMissing } from '@sasjs/utils/input/validators'
 
 /**
  * Converts the given JSON object array to a CSV string.


### PR DESCRIPTION
## Intent

Deprecating ClientID when login to SASJS server

## Implementation

Removed `ClientID` parameters from functions which works with SASJS server AUTH.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


**Ignore bottom checks since we will first merge to `auto-test` branch.**
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] All `sasjs-tests` are passing (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
