### PR TITLE
When expires csrf token, re-fetch and empty webout fix

### DIFF
--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -172,7 +172,7 @@ export class WebJobExecutor extends BaseJobExecutor {
           const resObj = res
 
           if (this.serverType === ServerType.Sasjs) {
-            if (res.result._webout < 1)
+            if (res.result._webout.length < 1)
               throw new JobExecutionError(
                 0,
                 'Job execution failed',

--- a/src/types/errors/InvalidCsrfError.ts
+++ b/src/types/errors/InvalidCsrfError.ts
@@ -1,0 +1,9 @@
+export class InvalidCsrfError extends Error {
+  constructor() {
+    const message = 'Invalid CSRF token!'
+
+    super(`Auth error: ${message}`)
+    this.name = 'InvalidCsrfError'
+    Object.setPrototypeOf(this, InvalidCsrfError.prototype)
+  }
+}


### PR DESCRIPTION
## Issue

Fixes #711 

## Intent

- Fix: infinite Promise waiting when webout empty
- Fix: when csrf token expired or not present, re-fetch it automatically.

## Implementation

- Created new error type `InvalidCsrfToken`
- Throwing error when matched
- Re-fetching token and resending request 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
