### PR TITLE
fix: parse the logs before appending the request to request array whe…

### DIFF
--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -169,18 +169,26 @@ export class WebJobExecutor extends BaseJobExecutor {
               ? res.result.log.map((logLine: any) => logLine.line).join('\n')
               : res.result.log
 
-          const resObj = res
-
-          if (this.serverType === ServerType.Sasjs) {
-            if (res.result._webout.length < 1)
-              throw new JobExecutionError(
-                0,
-                'Job execution failed',
-                parsedSasjsServerLog
-              )
-          }
+          const resObj =
+            this.serverType === ServerType.Sasjs
+              ? {
+                  result: res.result._webout,
+                  log: parsedSasjsServerLog
+                }
+              : res
 
           this.requestClient!.appendRequest(resObj, sasJob, config.debug)
+
+          if (
+            this.serverType === ServerType.Sasjs &&
+            res.result._webout.length < 1
+          ) {
+            throw new JobExecutionError(
+              0,
+              'Job execution failed',
+              parsedSasjsServerLog
+            )
+          }
 
           let jsonResponse = res.result
 

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -185,7 +185,7 @@ export class WebJobExecutor extends BaseJobExecutor {
           ) {
             throw new JobExecutionError(
               0,
-              'Job execution failed',
+              `No webout was returned by job ${program}. Server type is SASJS and the calling function is WebJobExecutor. Please check the SAS log for more info.`,
               parsedSasjsServerLog
             )
           }

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -177,8 +177,6 @@ export class WebJobExecutor extends BaseJobExecutor {
                 }
               : res
 
-          this.requestClient!.appendRequest(resObj, sasJob, config.debug)
-
           if (
             this.serverType === ServerType.Sasjs &&
             res.result._webout.length < 1
@@ -189,6 +187,8 @@ export class WebJobExecutor extends BaseJobExecutor {
               parsedSasjsServerLog
             )
           }
+
+          this.requestClient!.appendRequest(resObj, sasJob, config.debug)
 
           let jsonResponse = res.result
 


### PR DESCRIPTION
…n server type is sasjs

## Issue

closes #718 

## Intent

* show the log in request modals as plain text

## Implementation

* when server type is sasjs parse the logs before appending the request to the request history array because logs returned from sasjs server is of bit different shape as compared to viya and sas9. 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
