### PR TITLE
fix: do not throw job execution error if response contains >>weboutBEGIN<<

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -703,7 +703,14 @@ const parseError = (data: string) => {
   } catch (_) {}
 
   try {
+    // There are some edge cases in which the SAS mp_abort macro
+    // (https://core.sasjs.io/mp__abort_8sas.html) is unable to
+    // provide a clean exit.  In this case the JSON response will
+    // be wrapped in >>weboutBEGIN<< and >>weboutEND<< strings.
+    // Therefore, if the first string exists, we won't throw an
+    // error just yet (the parser may yet throw one instead)
     const hasError =
+      !data?.match(/>>weboutBEGIN<</) &&
       !!data?.match(/Stored Process Error/i) &&
       !!data?.match(/This request completed with errors./i)
     if (hasError) {


### PR DESCRIPTION
## Issue

closes #730 

## Intent

* There are some edge cases in which the SAS [mp_abort macro](https://core.sasjs.io/mp__abort_8sas.html) is unable to provide a clean exit.  In this case the JSON response will be wrapped in `>>weboutBEGIN<<` and `>>weboutEND<<` strings.
Therefore, if the first string exists, we won't throw `JobExecutionError` error from `parseError` function in `RequestClient`

## Implementation

* added an additional check to see if `>>weboutBEGIN<<` exists in response data

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
