### PR TITLE
fix: special missing double dot issue

### DIFF
--- a/src/test/utils/formatDataForRequest.spec.ts
+++ b/src/test/utils/formatDataForRequest.spec.ts
@@ -11,13 +11,16 @@ describe('formatDataForRequest', () => {
         { var1: 'string', var2: 232, nullvar: '_' },
         { var1: 'string', var2: 232, nullvar: 0 },
         { var1: 'string', var2: 232, nullvar: 'z' },
-        { var1: 'string', var2: 232, nullvar: null }
+        { var1: 'string', var2: 232, nullvar: null },
+        { var1: 'string', var2: 232, nullvar: '.A' },
+        { var1: 'string', var2: 232, nullvar: '._' },
+        { var1: 'string', var2: 232, nullvar: '.' }
       ],
       [`$${testTable}`]: { formats: { var1: '$char12.', nullvar: 'best.' } }
     }
 
     const expectedOutput = {
-      sasjs1data: `var1:$char12. var2:best. nullvar:best.\r\nstring,232,.a\r\nstring,232,.b\r\nstring,232,._\r\nstring,232,0\r\nstring,232,.z\r\nstring,232,.`,
+      sasjs1data: `var1:$char12. var2:best. nullvar:best.\r\nstring,232,.a\r\nstring,232,.b\r\nstring,232,._\r\nstring,232,0\r\nstring,232,.z\r\nstring,232,.\r\nstring,232,.a\r\nstring,232,._\r\nstring,232,.`,
       sasjs_tables: testTable
     }
 

--- a/src/utils/convertToCsv.ts
+++ b/src/utils/convertToCsv.ts
@@ -141,7 +141,9 @@ export const convertToCSV = (
           )
         }
 
-        return `.${value.toLowerCase()}`
+        const dot = value.includes('.') ? '' : '.'
+
+        return `${dot}${value.toLowerCase()}`
       }
 
       // if there any present, it should have preceding (") for escaping


### PR DESCRIPTION
## Issue

#733 

## Intent

During conversion to CSV, a check is added when an input data value is `special missing`, the dot is not added multiple times. If dot is missing, it will be added.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
