### PR TITLE
fix: add additional check for string type before converting data to lower case

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -611,7 +611,10 @@ export const throwIfError = (response: AxiosResponse) => {
         throw new LoginRequiredError(response.data)
       }
 
-      if (response.data.toLowerCase() === 'invalid csrf token!') {
+      if (
+        typeof response.data === 'string' &&
+        response.data.toLowerCase() === 'invalid csrf token!'
+      ) {
         throw new InvalidCsrfError()
       }
       break


### PR DESCRIPTION
## Issue

closes #721 

## Intent

* When service is not found, service $(program) was not found is being received from the server but it is being interrupted by another error i.e. `response.data.LowerCase` is not a function that is thrown when `response.data` is not a string

## Implementation

* added an additional check for `typeof response.data === 'string'`  

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
