### PR TITLE
fix(server): csrf cookie is created explicitly

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -223,9 +223,17 @@ export class AuthManager {
 
   private async getNewLoginForm() {
     if (this.serverType === ServerType.Sasjs) {
-      // server will be sending CSRF cookie,
+      // server will be sending CSRF token in response,
+      // need to save in cookie so that,
       // http client will use it automatically
-      return this.requestClient.get('/', undefined)
+      return this.requestClient.get('/', undefined).then(({ result }) => {
+        const cookie =
+          /<script>document.cookie = '(XSRF-TOKEN=.*; Max-Age=86400; SameSite=Strict; Path=\/;)'<\/script>/.exec(
+            result as string
+          )?.[1]
+
+        if (cookie) document.cookie = cookie
+      })
     }
 
     const { result: formResponse } = await this.requestClient.get<string>(

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -19,7 +19,7 @@ import {
   parseSourceCode,
   createAxiosInstance
 } from '../utils'
-import { InvalidCsrfError } from '../types/errors/InvalidCsrfError'
+import { InvalidSASjsCsrfError } from '../types/errors/InvalidSASjsCsrfError'
 
 export interface HttpClient {
   get<T>(
@@ -499,7 +499,7 @@ export class RequestClient implements HttpClient {
       throw e
     }
 
-    if (e instanceof InvalidCsrfError) {
+    if (e instanceof InvalidSASjsCsrfError) {
       // Fetching root and creating CSRF cookie
       await this.httpClient
         .get('/', {
@@ -623,7 +623,7 @@ export const throwIfError = (response: AxiosResponse) => {
         typeof response.data === 'string' &&
         response.data.toLowerCase() === 'invalid csrf token!'
       ) {
-        throw new InvalidCsrfError()
+        throw new InvalidSASjsCsrfError()
       }
       break
     case 401:

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -500,10 +500,18 @@ export class RequestClient implements HttpClient {
     }
 
     if (e instanceof InvalidCsrfError) {
-      // Fetching root will inject CSRF token in cookie
+      // Fetching root and creating CSRF cookie
       await this.httpClient
         .get('/', {
           withCredentials: true
+        })
+        .then((response) => {
+          const cookie =
+            /<script>document.cookie = '(XSRF-TOKEN=.*; Max-Age=86400; SameSite=Strict; Path=\/;)'<\/script>/.exec(
+              response.data
+            )?.[1]
+
+          if (cookie) document.cookie = cookie
         })
         .catch((err) => {
           throw prefixMessage(err, 'Error while re-fetching CSRF token.')

--- a/src/types/errors/InvalidCsrfError.ts
+++ b/src/types/errors/InvalidCsrfError.ts
@@ -1,9 +1,0 @@
-export class InvalidCsrfError extends Error {
-  constructor() {
-    const message = 'Invalid CSRF token!'
-
-    super(`Auth error: ${message}`)
-    this.name = 'InvalidCsrfError'
-    Object.setPrototypeOf(this, InvalidCsrfError.prototype)
-  }
-}

--- a/src/types/errors/InvalidSASjsCsrfError.ts
+++ b/src/types/errors/InvalidSASjsCsrfError.ts
@@ -1,0 +1,9 @@
+export class InvalidSASjsCsrfError extends Error {
+  constructor() {
+    const message = 'Invalid CSRF token!'
+
+    super(`Auth error: ${message}`)
+    this.name = 'InvalidSASjsCsrfError'
+    Object.setPrototypeOf(this, InvalidSASjsCsrfError.prototype)
+  }
+}


### PR DESCRIPTION
## Intent

Due to change in sasjs/server, [PR](https://github.com/sasjs/server/pull/248)
Need to update adapter behavior

## Implementation

Old Mechanism: makes request to root, and server sets cookie with `Set-Cookie`, and httpClient uses this cookie automatically.

New Mechanism: makes request to root, and server add csrf token to response, adapter creates cookie of it's own and httpClient uses this cookie automatically.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
