### PR TITLE
fix: update parse response method of sasjsRequestClient

### DIFF
--- a/src/request/SasjsRequestClient.ts
+++ b/src/request/SasjsRequestClient.ts
@@ -26,7 +26,7 @@ export class SasjsRequestClient extends RequestClient {
 
   protected parseResponse<T>(response: AxiosResponse<any>) {
     const etag = response?.headers ? response.headers['etag'] : ''
-    let parsedResponse
+    let parsedResponse = {}
     let log
 
     try {
@@ -37,10 +37,10 @@ export class SasjsRequestClient extends RequestClient {
       }
     } catch {
       if (response.data.includes(SASJS_LOGS_SEPARATOR)) {
-        parsedResponse = getValidJson(
-          response.data.split(SASJS_LOGS_SEPARATOR)[0]
-        )
-        log = response.data.split(SASJS_LOGS_SEPARATOR)[1]
+        const splittedResponse = response.data.split(SASJS_LOGS_SEPARATOR)
+        log = splittedResponse[1]
+        if (splittedResponse[0].trim())
+          parsedResponse = getValidJson(splittedResponse[0])
       } else parsedResponse = response.data
     }
 


### PR DESCRIPTION
## Issue

when `webout` is empty, `parseResponse` method from SasjsRequestClient class throws error


## Implementation

parse webout section only if it's not empty

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
