### PR TITLE
fix: should not assign error to parsedSasjsServeLog

### DIFF
--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -88,9 +88,6 @@ export class SASjsApiClient {
       .then((res: any) => {
         if (res.log) parsedSasjsServerLog = res.log
       })
-      .catch((err) => {
-        parsedSasjsServerLog = err
-      })
 
     return parsedSasjsServerLog
   }


### PR DESCRIPTION
## Intent

* should not catch an error from executeScript and assign it to `parsedSasjsServerLog`.
* we should let the calling code (cli / vscode) handle the error.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
