### PR TITLE
fix: sas9 public access denied handling

### DIFF
--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -187,6 +187,12 @@ export class WebJobExecutor extends BaseJobExecutor {
             { result: jsonResponse, log: res.log },
             extraResponseAttributes
           )
+
+          if (this.isPublicAccessDenied(jsonResponse))
+            reject(
+              new ErrorResponse('Public access has been denied', responseObject)
+            )
+
           resolve(responseObject)
         })
         .catch(async (e: Error) => {
@@ -261,5 +267,9 @@ export class WebJobExecutor extends BaseJobExecutor {
       }
     }
     return uri
+  }
+
+  private isPublicAccessDenied = (response: string): boolean => {
+    return /Public access has been denied/gm.test(response)
   }
 }

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -5,4 +5,5 @@ export interface LoginOptions {
 export interface LoginResult {
   isLoggedIn: boolean
   userName: string
+  errorMessage?: string
 }


### PR DESCRIPTION
## Issue

Fixes #150 

## Intent

Covers the SAS9 `Public Access Denied` scenario. 2 places touched:

1) `login()` - User is not logged in. The login function is called with `Public Account` credentials. The adapter will return an object that contains an error message with error details and `loggedIn` is false. (image 1.)
2) `request()` - User with `Public Account` is already logged in within current browser. App loads, `request` function is called. The adapter will throw an error with details inside. (image 2.)

image 1.
![public-access-on-login](https://user-images.githubusercontent.com/18329105/188933131-754eba8a-6b75-44f8-a705-5679eac63dd6.png)

image 2.
![public-access-on-request](https://user-images.githubusercontent.com/18329105/188933161-b6de1137-9dbd-4922-bc4b-9b3b5050c0de.png)

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
