### PR TITLE
Introduced user long name

### DIFF
--- a/src/auth/spec/AuthManager.spec.ts
+++ b/src/auth/spec/AuthManager.spec.ts
@@ -101,46 +101,20 @@ describe('AuthManager', () => {
           loginForm: null
         })
       )
-      jest
-        .spyOn(authManager, 'logOut')
-        .mockImplementation(() => Promise.resolve(true))
+      jest.spyOn(authManager, 'logOut')
 
-      jest
-        .spyOn<any, any>(authManager, 'getNewLoginForm')
-        .mockImplementation(() =>
-          Promise.resolve({
-            name: 'test'
-          })
-        )
-      mockedAxios.post.mockImplementation(() =>
-        Promise.resolve({ data: mockLoginSuccessResponse })
-      )
+      jest.spyOn<any, any>(authManager, 'getNewLoginForm')
+      jest.spyOn<any, any>(authManager, 'sendLoginRequest')
 
       const loginResponse = await authManager.logIn(userName, password)
 
       expect(loginResponse.isLoggedIn).toBeTruthy()
       expect(loginResponse.userName).toEqual(userName)
 
-      const loginParams = serialize({
-        _service: 'default',
-        username: userName,
-        password,
-        name: 'test'
-      })
       expect(authCallback).toHaveBeenCalledTimes(1)
-      expect(authManager.logOut).toHaveBeenCalledTimes(1)
-      expect(authManager['getNewLoginForm']).toHaveBeenCalledTimes(1)
-      expect(mockedAxios.post).toHaveBeenCalledWith(
-        `/SASLogon/login`,
-        loginParams,
-        {
-          withCredentials: true,
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Accept: '*/*'
-          }
-        }
-      )
+      expect(authManager.logOut).toHaveBeenCalledTimes(0)
+      expect(authManager['getNewLoginForm']).toHaveBeenCalledTimes(0)
+      expect(authManager['sendLoginRequest']).toHaveBeenCalledTimes(0)
       expect(authCallback).toHaveBeenCalledTimes(1)
     })
 
@@ -567,43 +541,8 @@ describe('AuthManager', () => {
       )
     })
 
-    it('return session information when logged in - SAS9', async () => {
-      // username cannot have `-` and cannot be uppercased
-      const username = 'testusername'
-      const serverType = ServerType.Sas9
-      const authManager = new AuthManager(
-        serverUrl,
-        serverType,
-        requestClient,
-        authCallback
-      )
-      mockedAxios.get.mockImplementation(() =>
-        Promise.resolve({
-          data: `"title":"Log Off ${username}","url":"javascript: clearFrame(\"/SASStoredProcess/do?_action=logoff\")"' })`
-        })
-      )
-
-      const response = await authManager.checkSession()
-      expect(response.isLoggedIn).toBeTruthy()
-      expect(response.userName).toEqual(username)
-      expect(mockedAxios.get).toHaveBeenNthCalledWith(
-        1,
-        `http://test-server.com/SASStoredProcess`,
-        {
-          withCredentials: true,
-          responseType: 'text',
-          transformResponse: undefined,
-          headers: {
-            Accept: '*/*',
-            'Content-Type': 'text/plain'
-          }
-        }
-      )
-    })
-
     it('return session information when logged in - SAS9 - having full name in html', async () => {
       const fullname = 'FirstName LastName'
-      const username = 'firlas'
       const serverType = ServerType.Sas9
       const authManager = new AuthManager(
         serverUrl,
@@ -619,7 +558,8 @@ describe('AuthManager', () => {
 
       const response = await authManager.checkSession()
       expect(response.isLoggedIn).toBeTruthy()
-      expect(response.userName).toEqual(username)
+      expect(response.userName).toEqual('')
+      expect(response.userLongName).toEqual(fullname)
       expect(mockedAxios.get).toHaveBeenNthCalledWith(
         1,
         `http://test-server.com/SASStoredProcess`,

--- a/src/auth/spec/AuthManager.spec.ts
+++ b/src/auth/spec/AuthManager.spec.ts
@@ -20,6 +20,7 @@ describe('AuthManager', () => {
   const serverUrl = 'http://test-server.com'
   const serverType = ServerType.SasViya
   const userName = 'test-username'
+  const userLongName = 'test-user long name'
   const password = 'test-password'
   const requestClient = new RequestClient(serverUrl)
 
@@ -73,6 +74,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: true,
           userName,
+          userLongName,
           loginForm: 'test'
         })
       )
@@ -95,6 +97,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: true,
           userName: 'someOtherUsername',
+          userLongName: 'someOtherUser Long name',
           loginForm: null
         })
       )
@@ -152,6 +155,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: false,
           userName: '',
+          userLongName: '',
           loginForm: { name: 'test' }
         })
       )
@@ -196,6 +200,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: false,
           userName: '',
+          userLongName: '',
           loginForm: { name: 'test' }
         })
       )
@@ -245,6 +250,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: false,
           userName: '',
+          userLongName: '',
           loginForm: { name: 'test' }
         })
       )
@@ -290,6 +296,7 @@ describe('AuthManager', () => {
         Promise.resolve({
           isLoggedIn: false,
           userName: 'test',
+          userLongName: 'test Long name',
           loginForm: { name: 'test' }
         })
       )

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -5,4 +5,11 @@ export interface LoginOptions {
 export interface LoginResult {
   isLoggedIn: boolean
   userName: string
+  userLongName: string
+}
+export interface LoginResultInternal {
+  isLoggedIn: boolean
+  userName: string
+  userLongName: string
+  loginForm?: any
 }

--- a/src/utils/sas9/extractUserLongNameSas9.ts
+++ b/src/utils/sas9/extractUserLongNameSas9.ts
@@ -5,11 +5,11 @@
 const dictionary = ['Log Off']
 
 /**
- * Extracts username assuming the first word after "title" means log off if not found otherwise in the dictionary
+ * Extracts user full name assuming the first word after "title" means log off if not found otherwise in the dictionary
  * @param response SAS response content
- * @returns username
+ * @returns user full name
  */
-export const extractUserNameSas9 = (response: string) => {
+export const extractUserLongNameSas9 = (response: string) => {
   const regex = /"title":\s?".*?"/
 
   const matched = response?.match(regex)
@@ -27,17 +27,5 @@ export const extractUserNameSas9 = (response: string) => {
   })
 
   //Cut only name
-  let username = fullName.slice(breakIndex, -1).trim()
-
-  //Create username by SAS method - first 3 chars of every word lowercase
-  const usernameSplit = username.split(' ')
-  username = usernameSplit
-    .map((name: string) =>
-      usernameSplit.length > 1
-        ? name.slice(0, 3).toLowerCase()
-        : name.toLowerCase()
-    )
-    .join('')
-
-  return username
+  return fullName.slice(breakIndex, -1).trim()
 }

--- a/src/utils/spec/extractUserLongNameSas9.spec.ts
+++ b/src/utils/spec/extractUserLongNameSas9.spec.ts
@@ -1,32 +1,32 @@
-import { extractUserNameSas9 } from '../sas9/extractUserNameSas9'
+import { extractUserLongNameSas9 } from '../sas9/extractUserLongNameSas9'
 
 describe('Extract username SAS9 English - two word logout handled language', () => {
   const logoutWord = 'Log Off'
 
   it('should return username with space after colon', () => {
     const response = `                  "title": "${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuseone')
+    expect(username).toEqual('SAS User One')
   })
 
   it('should return username without space after colon', () => {
     const response = `                  "title":"${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuseone')
+    expect(username).toEqual('SAS User One')
   })
 
   it('should return username with one word user name', () => {
     const response = `                  "title": "${logoutWord} SasUserOne",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuserone')
+    expect(username).toEqual('SasUserOne')
   })
 
   it('should return username unknown', () => {
     const response = `                  invalid",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
     expect(username).toEqual('unknown')
   })
@@ -37,28 +37,28 @@ describe('Extract username SAS9 two word logout unhandled language', () => {
 
   it('should return username with space after colon', () => {
     const response = `                  "title": "${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('outsasuseone')
+    expect(username).toEqual('out SAS User One')
   })
 
   it('should return username without space after colon', () => {
     const response = `                  "title":"${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('outsasuseone')
+    expect(username).toEqual('out SAS User One')
   })
 
   it('should return username with one word user name', () => {
     const response = `                  "title": "${logoutWord} SasUserOne",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('outsas')
+    expect(username).toEqual('out SasUserOne')
   })
 
   it('should return username unknown', () => {
     const response = `                  invalid",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
     expect(username).toEqual('unknown')
   })
@@ -69,28 +69,28 @@ describe('Extract username SAS9 Spanish - one word logout languages', () => {
 
   it('should return username with space after colon', () => {
     const response = `                  "title": "${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuseone')
+    expect(username).toEqual('SAS User One')
   })
 
   it('should return username without space after colon', () => {
     const response = `                  "title":"${logoutWord} SAS User One",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuseone')
+    expect(username).toEqual('SAS User One')
   })
 
   it('should return username with one word user name', () => {
     const response = `                  "title": "${logoutWord} SasUserOne",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
-    expect(username).toEqual('sasuserone')
+    expect(username).toEqual('SasUserOne')
   })
 
   it('should return username unknown', () => {
     const response = `                  invalid",`
-    const username = extractUserNameSas9(response)
+    const username = extractUserLongNameSas9(response)
 
     expect(username).toEqual('unknown')
   })


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

Cannot fetch username in case of `SAS9`

## Implementation

Added another property `userLongName` to Login Response along `userName`.
Upon login if already loggedIn, returning with that information.
Also renamed `extractUserNameSas9` to `extractUserLongNameSas9` with it's test

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
