### PR TITLE
fix: remove the invocation of checkNodeVersion script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/utils": "2.44.0",
+        "@sasjs/utils": "2.48.2",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
@@ -2792,9 +2792,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.44.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.44.0.tgz",
-      "integrity": "sha512-hpC4erHYA8Mcb38mzxFEP0cXehfa0iKeqSW2d9MmxZ9g2qpy0BU6xyZJohN9kOiafXo5H359ndNKsg4DOq5YgA==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
+      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -19001,9 +19001,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.44.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.44.0.tgz",
-      "integrity": "sha512-hpC4erHYA8Mcb38mzxFEP0cXehfa0iKeqSW2d9MmxZ9g2qpy0BU6xyZJohN9kOiafXo5H359ndNKsg4DOq5YgA==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
+      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "description": "JavaScript adapter for SAS",
   "homepage": "https://adapter.sasjs.io",
   "scripts": {
-    "preinstall": "node checkNodeVersion",
-    "prebuild": "node checkNodeVersion",
+    "nodeVersionMessage": "echo \u001b[33m make sure you are running node lts version \u001b[0m",
+    "preinstall": "npm run nodeVersionMessage",
+    "prebuild": "npm run nodeVersionMessage",
     "build": "rimraf build && rimraf node && mkdir node && copyfiles -u 1 \"./src/**/*\" ./node && webpack && rimraf build/src && rimraf node",
-    "package:lib": "npm run build && copyfiles ./package.json ./checkNodeVersion.js build && cd build && npm version \"5.0.0\" && npm pack",
+    "package:lib": "npm run build && copyfiles ./package.json build && cd build && npm version \"5.0.0\" && npm pack",
     "publish:lib": "npm run build && cd build && npm publish",
     "lint:fix": "npx prettier --loglevel silent --write \"src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --loglevel silent --write \"sasjs-tests/src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --loglevel silent --write \"cypress/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
     "lint": "npx prettier --check \"src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --check \"sasjs-tests/src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --check \"cypress/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
@@ -78,7 +79,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@sasjs/utils": "2.44.0",
+    "@sasjs/utils": "2.48.2",
     "axios": "0.26.0",
     "axios-cookiejar-support": "1.0.1",
     "form-data": "4.0.0",


### PR DESCRIPTION

## Intent

* calling checkNodeVersion script in preinstalling and prebuild steps causes some unexpected problems. So ,removed the invocation of this script from the package.json file and rather add a new script that will advise to use node lts version



## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
