### PR TITLE
fix: createReadStream import where needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/utils": "2.48.2",
+        "@sasjs/utils": "2.52.0",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
@@ -1575,9 +1575,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
-      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -16627,9 +16627,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
-      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@sasjs/utils": "2.48.2",
+    "@sasjs/utils": "2.52.0",
     "axios": "0.26.0",
     "axios-cookiejar-support": "1.0.1",
     "form-data": "4.0.0",

--- a/src/SASjsApiClient.ts
+++ b/src/SASjsApiClient.ts
@@ -1,5 +1,4 @@
 import * as NodeFormData from 'form-data'
-import { createReadStream } from '@sasjs/utils/file'
 import { AuthConfig, ServerType, ServicePackSASjs } from '@sasjs/utils/types'
 import { ExecutionQuery } from './types'
 import { RequestClient } from './request/RequestClient'
@@ -62,6 +61,7 @@ export class SASjsApiClient {
    * @param authConfig - (optional) a valid client, secret, refresh and access tokens that are authorised to execute compute jobs.
    */
   public async deployZipFile(zipFilePath: string, authConfig?: AuthConfig) {
+    const { createReadStream } = require('@sasjs/utils/file')
     const access_token = await this.getAccessTokenForRequest(authConfig)
 
     const file = await createReadStream(zipFilePath)


### PR DESCRIPTION
# Intent

`createReadStream` depends on `fs` which is node-specific util, so we import it inside of the node-specific function because importing globally was failing on the Browser environment.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
