### PR TITLE
fix: improve error message when sasjs runner is not found

### DIFF
--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -691,7 +691,9 @@ const parseError = (data: string) => {
       const parts = data.split(/stored process not found: /i)
       if (parts.length > 1) {
         const storedProcessPath = parts[1].split('<i>')[1].split('</i>')[0]
-        const message = `Stored process not found: ${storedProcessPath}`
+        const message = storedProcessPath.endsWith('runner')
+          ? `SASJS runner not found. Here's the link (https://cli.sasjs.io/auth/#sasjs-runner) to sas code for registering sasjs runner`
+          : `Stored process not found: ${storedProcessPath}`
         return new JobExecutionError(500, message, '')
       }
     }

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -692,7 +692,7 @@ const parseError = (data: string) => {
       if (parts.length > 1) {
         const storedProcessPath = parts[1].split('<i>')[1].split('</i>')[0]
         const message = storedProcessPath.endsWith('runner')
-          ? `SASJS runner not found. Here's the link (https://cli.sasjs.io/auth/#sasjs-runner) to sas code for registering sasjs runner`
+          ? `SASJS runner not found. Here's the link (https://cli.sasjs.io/auth/#sasjs-runner) to the SAS code for registering the SASjs runner`
           : `Stored process not found: ${storedProcessPath}`
         return new JobExecutionError(500, message, '')
       }


### PR DESCRIPTION
## Issue

closes #777

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
