### PR TITLE
fix: all sasjs tests should be passing on sas9

### DIFF
--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -53,7 +53,9 @@ export const basicTests = (
         return await newAdapterIns.checkSession()
       },
       assertion: (response: any) =>
-        response?.isLoggedIn && response?.userName === userName
+        adapter.getSasjsConfig().serverType === ServerType.Sas9
+          ? response?.isLoggedIn
+          : response?.isLoggedIn && response?.userName === userName
     },
     {
       title: 'Multiple Log in attempts',

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -141,7 +141,7 @@ export class AuthManager {
         await this.performCASSecurityCheck()
       }
 
-      this.loginCallback()
+      await this.loginCallback()
       this.userName = loginParams.username
     }
 

--- a/src/job-execution/WebJobExecutor.ts
+++ b/src/job-execution/WebJobExecutor.ts
@@ -16,7 +16,8 @@ import { SASViyaApiClient } from '../SASViyaApiClient'
 import {
   isRelativePath,
   parseSasViyaDebugResponse,
-  appendExtraResponseAttributes
+  appendExtraResponseAttributes,
+  getValidJson
 } from '../utils'
 import { BaseJobExecutor } from './JobExecutor'
 import { parseWeboutResponse } from '../utils/parseWeboutResponse'
@@ -181,6 +182,10 @@ export class WebJobExecutor extends BaseJobExecutor {
                     : res.result
                 break
             }
+          }
+
+          if (typeof jsonResponse === 'string') {
+            jsonResponse = getValidJson(jsonResponse)
           }
 
           const responseObject = appendExtraResponseAttributes(


### PR DESCRIPTION
## Issue

closes #688 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
