### PR TITLE
Sasjs executor not re-sending waiting requests

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -895,6 +895,7 @@ export default class SASjs {
     await this.computeJobExecutor?.resendWaitingRequests()
     await this.jesJobExecutor?.resendWaitingRequests()
     await this.fileUploader?.resendWaitingRequests()
+    await this.sasjsJobExecutor?.resendWaitingRequests()
   }
 
   /**


### PR DESCRIPTION
## Issue

Fixes #783

## Intent

Re-sending the waiting requests function was not called in the `sasjsJobExecutor` 

## Implementation

Added the function call.

## Checks

No PR (that involves a non-trivial code change) should be merged unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
