### PR TITLE
fix: removing .do from loginUrl mechanism

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -239,7 +239,7 @@ export class AuthManager {
     }
 
     const { result: formResponse } = await this.requestClient.get<string>(
-      this.loginUrl.replace('.do', ''),
+      this.loginUrl.replace('login.do', 'login'),
       undefined,
       'text/plain'
     )
@@ -348,7 +348,7 @@ export class AuthManager {
       this.loginUrl =
         this.serverType === ServerType.SasViya
           ? tempLoginLink
-          : loginUrl.replace('.do', '')
+          : loginUrl.replace('login.do', 'login')
     }
   }
 

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -239,7 +239,7 @@ export class AuthManager {
     }
 
     const { result: formResponse } = await this.requestClient.get<string>(
-      this.loginUrl.replace('login.do', 'login'),
+      this.loginUrl.replace('/SASLogon/login.do', '/SASLogon/login'),
       undefined,
       'text/plain'
     )
@@ -348,7 +348,7 @@ export class AuthManager {
       this.loginUrl =
         this.serverType === ServerType.SasViya
           ? tempLoginLink
-          : loginUrl.replace('login.do', 'login')
+          : loginUrl.replace('/SASLogon/login.do', '/SASLogon/login')
     }
   }
 


### PR DESCRIPTION
## Issue

Fixes #786

## Intent

Improving matching string  that removes `.do` from login url, when not `VIYA`

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
