### PR TITLE
fix: throw error as it is when its an instance of JobExecutionError

### DIFF
--- a/src/request/Sas9RequestClient.ts
+++ b/src/request/Sas9RequestClient.ts
@@ -4,6 +4,7 @@ import axiosCookieJarSupport from 'axios-cookiejar-support'
 import * as tough from 'tough-cookie'
 import { prefixMessage } from '@sasjs/utils/error'
 import { RequestClient, throwIfError } from './RequestClient'
+import { JobExecutionError } from '../types/errors'
 
 /**
  * Specific request client for SAS9 in Node.js environments.
@@ -69,6 +70,8 @@ export class Sas9RequestClient extends RequestClient {
         return this.parseResponse<T>(response)
       })
       .catch(async (e: any) => {
+        if (e instanceof JobExecutionError) throw e
+
         return await this.handleError(
           e,
           () =>


### PR DESCRIPTION
## Issue

fixes sasjs/cli#1318


## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
