### PR TITLE
fix: sas9 m8 redirected login

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -13,7 +13,7 @@ export class AuthManager {
   public userLongName = ''
   private loginUrl: string
   private logoutUrl: string
-  private redirectedLoginUrl = `/SASLogon/home`
+  private redirectedLoginUrl = `/SASLogon` //SAS 9 M8 no longer redirects from `/SASLogon/home` to the login page. `/SASLogon` seems to be stable enough across SAS versions
   constructor(
     private serverUrl: string,
     private serverType: ServerType,


### PR DESCRIPTION
## Issue

Fixes #796

## Intent

There is an issue with redirected login on SAS 9, M8 no longer redirects from `/SASLogon/home` to the login page. 

## Implementation

We changed it to `/SASLogon` as it seems it provides stable results across SAS versions.

## Checks

No PR (that involves a non-trivial code change) should be merged unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
