### PR TITLE
ErrorBody interface made public

### DIFF
--- a/src/types/errors/ErrorResponse.ts
+++ b/src/types/errors/ErrorResponse.ts
@@ -21,8 +21,8 @@ export class ErrorResponse {
   }
 }
 
-interface ErrorBody {
+export interface ErrorBody {
   message: string
-  details: string
+  details: any
   raw: any
 }


### PR DESCRIPTION
## Issue

Closes #680 

## Intent

Since the issue was opened a long time ago and quite some stuff changed, I propose that we make this interface public to be available for use in client apps.
This change should not introduce any issues since it is just exporting the interface.
Ideally `details` property in that interface should have a better-defined type than `any`. But for that to be achieved we need to find and change every single place where errors are returned.
We can do it in future, bit by bit, when we find such places while fixing/adding features.

## Implementation

`ErrorBody` in the `ErrorResponse.ts` file exported.