### PR TITLE
fix(refreshTokensForViya): fixed FormData logic

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -548,6 +548,7 @@ export class SASViyaApiClient {
 
   /**
    * Exchanges the refresh token for an access token for the given client.
+   * This method can only be used by Node.
    * @param clientId - the client ID to authenticate with.
    * @param clientSecret - the client secret to authenticate with.
    * @param refreshToken - the refresh token received from the server.

--- a/src/auth/getTokens.ts
+++ b/src/auth/getTokens.ts
@@ -10,6 +10,7 @@ import { refreshTokensForSasjs } from './refreshTokensForSasjs'
 
 /**
  * Returns the auth configuration, refreshing the tokens if necessary.
+ * This function can only be used by Node, if a server type is SASVIYA.
  * @param requestClient - the pre-configured HTTP request client
  * @param authConfig - an object containing a client ID, secret, access token and refresh token
  * @param serverType - server type for which refreshing the tokens, defaults to SASVIYA

--- a/src/auth/getTokens.ts
+++ b/src/auth/getTokens.ts
@@ -29,9 +29,12 @@ export async function getTokens(
       const error =
         'Unable to obtain new access token. Your refresh token has expired.'
       logger.error(error)
+
       throw new Error(error)
     }
+
     logger.info('Refreshing access and refresh tokens.')
+
     const tokens =
       serverType === ServerType.SasViya
         ? await refreshTokensForViya(

--- a/src/auth/refreshTokensForViya.ts
+++ b/src/auth/refreshTokensForViya.ts
@@ -17,6 +17,10 @@ export async function refreshTokensForViya(
   clientSecret: string,
   refreshToken: string
 ) {
+  if (!isNode()) {
+    throw new Error(`Method 'refreshTokensForViya' can only be used by Node.`)
+  }
+
   const url = '/SASLogon/oauth/token'
   const token =
     typeof Buffer === 'undefined'
@@ -27,7 +31,7 @@ export async function refreshTokensForViya(
     Authorization: 'Basic ' + token
   }
 
-  const formData = isNode() ? new NodeFormData() : new FormData()
+  const formData = new NodeFormData()
   formData.append('grant_type', 'refresh_token')
   formData.append('refresh_token', refreshToken)
 

--- a/src/auth/refreshTokensForViya.ts
+++ b/src/auth/refreshTokensForViya.ts
@@ -2,6 +2,7 @@ import { SasAuthResponse } from '@sasjs/utils/types'
 import { prefixMessage } from '@sasjs/utils/error'
 import * as NodeFormData from 'form-data'
 import { RequestClient } from '../request/RequestClient'
+import { isNode } from '../utils'
 
 /**
  * Exchanges the refresh token for an access token for the given client.
@@ -17,8 +18,7 @@ export async function refreshTokensForViya(
   refreshToken: string
 ) {
   const url = '/SASLogon/oauth/token'
-  let token
-  token =
+  const token =
     typeof Buffer === 'undefined'
       ? btoa(clientId + ':' + clientSecret)
       : Buffer.from(clientId + ':' + clientSecret).toString('base64')
@@ -27,8 +27,7 @@ export async function refreshTokensForViya(
     Authorization: 'Basic ' + token
   }
 
-  const formData =
-    typeof FormData === 'undefined' ? new NodeFormData() : new FormData()
+  const formData = isNode() ? new NodeFormData() : new FormData()
   formData.append('grant_type', 'refresh_token')
   formData.append('refresh_token', refreshToken)
 

--- a/src/auth/refreshTokensForViya.ts
+++ b/src/auth/refreshTokensForViya.ts
@@ -6,6 +6,7 @@ import { isNode } from '../utils'
 
 /**
  * Exchanges the refresh token for an access token for the given client.
+ * This function can only be used by Node.
  * @param requestClient - the pre-configured HTTP request client
  * @param clientId - the client ID to authenticate with.
  * @param clientSecret - the client secret to authenticate with.

--- a/src/auth/spec/refreshTokensForViya.spec.ts
+++ b/src/auth/spec/refreshTokensForViya.spec.ts
@@ -3,6 +3,7 @@ import * as NodeFormData from 'form-data'
 import { generateToken, mockAuthResponse } from './mockResponses'
 import { RequestClient } from '../../request/RequestClient'
 import { refreshTokensForViya } from '../refreshTokensForViya'
+import * as IsNodeModule from '../../utils/isNode'
 
 const requestClient = new (<jest.Mock<RequestClient>>RequestClient)()
 
@@ -69,6 +70,18 @@ describe('refreshTokensForViya', () => {
     ).catch((e: any) => e)
 
     expect(error).toEqual(`Error while refreshing tokens: ${tokenError}`)
+  })
+
+  it('should throw an error if environment is not Node', async () => {
+    jest.spyOn(IsNodeModule, 'isNode').mockImplementation(() => false)
+
+    const expectedError = new Error(
+      `Method 'refreshTokensForViya' can only be used by Node.`
+    )
+
+    expect(
+      refreshTokensForViya(requestClient, 'client', 'secret', 'token')
+    ).rejects.toEqual(expectedError)
   })
 })
 


### PR DESCRIPTION
## Issue

Because typeof `FormData` is `function` for node and browser environments, it is right to compare it to `undefined`.

## Intent

Fix sending form data to `/SASLogon/oauth/token` endpoint in order to refresh access token.

## Implementation

`isNode` utility is used to check if the environment is `node` to use a correct instance of `FormData` from `form-data` package.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
