### PR TITLE
fix(packaging): fixed output file for Node

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,8 @@ const nodeConfig = {
   entry: './node/index.ts',
   output: {
     ...browserConfig.output,
-    path: path.resolve(__dirname, 'build', 'node')
+    path: path.resolve(__dirname, 'build', 'node'),
+    filename: 'index.js'
   }
 }
 


### PR DESCRIPTION
## Intent

Fix packaged output file name for Node.
By default, webpack is using `main.js` as a file name which is not correct for this project and results into the following error:

`Error: Cannot find module '@sasjs/adapter/node'`


## Implementation

Explicitly set `filename` in `nodeConfig` of the webpack.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
