### PR TITLE
fix(job-execution): fixed webout for SASJS server type

### DIFF
--- a/src/job-execution/SasjsJobExecutor.ts
+++ b/src/job-execution/SasjsJobExecutor.ts
@@ -13,7 +13,11 @@ import { generateFileUploadForm } from '../file/generateFileUploadForm'
 
 import { RequestClient } from '../request/RequestClient'
 
-import { isRelativePath, appendExtraResponseAttributes } from '../utils'
+import {
+  isRelativePath,
+  appendExtraResponseAttributes,
+  getValidJson
+} from '../utils'
 import { BaseJobExecutor } from './JobExecutor'
 
 export class SasjsJobExecutor extends BaseJobExecutor {
@@ -89,12 +93,16 @@ export class SasjsJobExecutor extends BaseJobExecutor {
             )
           }
 
+          const { result } = res.result
+          if (result && result.trim()) res.result = getValidJson(result)
+
           this.requestClient!.appendRequest(res, sasJob, config.debug)
 
           const responseObject = appendExtraResponseAttributes(
             res,
             extraResponseAttributes
           )
+
           resolve(responseObject)
         })
         .catch(async (e: Error) => {

--- a/src/request/SasjsRequestClient.ts
+++ b/src/request/SasjsRequestClient.ts
@@ -1,6 +1,14 @@
 import { RequestClient } from './RequestClient'
 import { AxiosResponse } from 'axios'
-import { SASJS_LOGS_SEPARATOR, getValidJson } from '../utils'
+import { SASJS_LOGS_SEPARATOR } from '../utils'
+
+interface SasjsParsedResponse<T> {
+  result: T
+  log: string
+  etag: string
+  status: number
+  printOutput?: string
+}
 
 /**
  * Specific request client for SASJS.
@@ -27,7 +35,7 @@ export class SasjsRequestClient extends RequestClient {
   protected parseResponse<T>(response: AxiosResponse<any>) {
     const etag = response?.headers ? response.headers['etag'] : ''
     let parsedResponse = {}
-    let log
+    let webout, log, printOutput
 
     try {
       if (typeof response.data === 'string') {
@@ -38,17 +46,26 @@ export class SasjsRequestClient extends RequestClient {
     } catch {
       if (response.data.includes(SASJS_LOGS_SEPARATOR)) {
         const splittedResponse = response.data.split(SASJS_LOGS_SEPARATOR)
+
+        webout = splittedResponse[0]
+        if (webout) parsedResponse = webout
+
         log = splittedResponse[1]
-        if (splittedResponse[0].trim())
-          parsedResponse = getValidJson(splittedResponse[0])
-      } else parsedResponse = response.data
+        printOutput = splittedResponse[2]
+      } else {
+        parsedResponse = response.data
+      }
     }
 
-    return {
+    const returnResult: SasjsParsedResponse<T> = {
       result: parsedResponse as T,
       log,
       etag,
       status: response.status
     }
+
+    if (printOutput) returnResult.printOutput = printOutput
+
+    return returnResult
   }
 }

--- a/src/utils/getValidJson.ts
+++ b/src/utils/getValidJson.ts
@@ -17,6 +17,7 @@ export const getValidJson = (str: string | object): object => {
     return JSON.parse(str)
   } catch (e: any) {
     if (e instanceof JsonParseArrayError) throw e
+
     throw new InvalidJsonError()
   }
 }


### PR DESCRIPTION
## Issue

`webout` for `SASJS` server type can be anything, but for other server types it has to be a valid json.

## Intent

Improve `webout` processing for different server types.

## Implementation

- Moved geting `webout` json from `src/request/SasjsRequestClient.ts` to `src/job-execution/SasjsJobExecutor.ts`.
- Added `printOutput` to response payload for `SASJS` server type.
- Improved types declaration.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
