### PR TITLE
fix(sasjs-request-client): fixed response parsing

### DIFF
--- a/src/request/SasjsRequestClient.ts
+++ b/src/request/SasjsRequestClient.ts
@@ -48,7 +48,7 @@ export class SasjsRequestClient extends RequestClient {
         const splittedResponse = response.data.split(SASJS_LOGS_SEPARATOR)
 
         webout = splittedResponse[0]
-        if (webout) parsedResponse = webout
+        if (webout !== undefined) parsedResponse = webout
 
         log = splittedResponse[1]
         printOutput = splittedResponse[2]


### PR DESCRIPTION
## Issue

An empty `WEBOUT` has been incorrectly parsed for `SASJS` server type.

## Intent

- Improve the `parseResponse` method of the `SasjsRequestClient` class.

## Implementation

- Fixed `webout` type checking in the `parseResponse` method.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
