### PR TITLE
fix: issue with parsing json in sasjs job executor

### DIFF
--- a/src/job-execution/SasjsJobExecutor.ts
+++ b/src/job-execution/SasjsJobExecutor.ts
@@ -93,8 +93,10 @@ export class SasjsJobExecutor extends BaseJobExecutor {
             )
           }
 
-          const { result } = res.result
-          if (result && result.trim()) res.result = getValidJson(result)
+          const { result } = res
+
+          if (result && typeof result === 'string' && result.trim())
+            res.result = getValidJson(result)
 
           this.requestClient!.appendRequest(res, sasJob, config.debug)
 


### PR DESCRIPTION
## Issue is caught in DataController when filtering.

![image](https://github.com/sasjs/adapter/assets/18329105/6a4fc12c-dc60-47c2-88e9-3732541879e7)

## The cause
In this commit these lines have been added to parse the json, if response comes in as string, which happens when debug is on. 

https://github.com/sasjs/adapter/commit/2d6efa2437231e5e9a4920ef3a025666d9ef2c32#diff-663fa65ded8381d80ed08a8d0518b473a97b8aec1c135767a988d1579e6cbf85R96-R98

## Implementation

- First issue is `.trim()` function in the condition, if the response is of a type `object` it will fail because `trim()` is not a function that exists inside.
- Second issue is `{ result } = res.result` that will resolve as `res.result.result` which is one level too deep. 

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
