### PR TITLE
feat(request-client): implemented verbose mode

### DIFF
--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -863,7 +863,8 @@ export default class SASjs {
     waitForResult?: boolean,
     pollOptions?: PollOptions,
     printPid = false,
-    variables?: MacroVar
+    variables?: MacroVar,
+    verboseMode?: boolean
   ) {
     config = {
       ...this.sasjsConfig,
@@ -876,6 +877,9 @@ export default class SASjs {
         'Context name is undefined. Please set a `contextName` in your SASjs or override config.'
       )
     }
+
+    if (verboseMode) this.requestClient?.enableVerboseMode()
+    else this.requestClient?.disableVerboseMode()
 
     return this.sasViyaApiClient?.executeComputeJob(
       sasJob,

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -854,6 +854,7 @@ export default class SASjs {
    * @param pollOptions - an object that represents poll interval(milliseconds) and maximum amount of attempts. Object example: { maxPollCount: 24 * 60 * 60, pollInterval: 1000 }. More information available at src/api/viya/pollJobState.ts.
    * @param printPid - a boolean that indicates whether the function should print (PID) of the started job.
    * @param variables - an object that represents macro variables.
+   * @param verboseMode - boolean to enable verbose mode (log every HTTP response).
    */
   public async startComputeJob(
     sasJob: string,

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -393,13 +393,24 @@ export class RequestClient implements HttpClient {
       })
   }
 
+  /**
+   * Adds colors to the string.
+   * @param str - string to be prettified.
+   * @returns - prettified string
+   */
   private prettifyString = (str: any) => inspect(str, { colors: true })
 
+  /**
+   * Formats HTTP request/response body.
+   * @param body - HTTP request/response body.
+   * @returns - formatted string.
+   */
   private parseInterceptedBody = (body: any) => {
     if (!body) return ''
 
     let parsedBody
 
+    // Tries to parse body into JSON object.
     if (typeof body === 'string') {
       try {
         parsedBody = JSON.parse(body)
@@ -412,6 +423,7 @@ export class RequestClient implements HttpClient {
 
     const bodyLines = this.prettifyString(parsedBody).split('\n')
 
+    // Leaves first 50 lines
     if (bodyLines.length > 51) {
       bodyLines.splice(50)
       bodyLines.push('...')
@@ -426,6 +438,8 @@ export class RequestClient implements HttpClient {
     const { _header: reqHeaders, res } = request
     const { rawHeaders } = res
 
+    // Converts an array of strings into a single string with the following format:
+    // <headerName>: <headerValue>
     const resHeaders = rawHeaders.reduce(
       (acc: string, value: string, i: number) => {
         if (i % 2 === 0) {
@@ -441,6 +455,7 @@ export class RequestClient implements HttpClient {
 
     const parsedResBody = this.parseInterceptedBody(resData)
 
+    // HTTP response summary.
     process.logger?.info(`HTTP Request (first 50 lines):
 ${reqHeaders}${this.parseInterceptedBody(reqData)}
 
@@ -453,6 +468,11 @@ ${resHeaders}${parsedResBody ? `\n\n${parsedResBody}` : ''}
     return response
   }
 
+  /**
+   * Turns on verbose mode to log every HTTP response.
+   * @param successCallBack - function that should be triggered on every HTTP response with the status 2**.
+   * @param errorCallBack - function that should be triggered on every HTTP response with the status different from 2**.
+   */
   public enableVerboseMode = (
     successCallBack = this.defaultInterceptionCallBack,
     errorCallBack = this.defaultInterceptionCallBack
@@ -463,6 +483,9 @@ ${resHeaders}${parsedResBody ? `\n\n${parsedResBody}` : ''}
     )
   }
 
+  /**
+   * Turns off verbose mode to log every HTTP response.
+   */
   public disableVerboseMode = () => {
     if (this.httpInterceptor) {
       this.httpClient.interceptors.response.eject(this.httpInterceptor)

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -20,6 +20,7 @@ import {
   createAxiosInstance
 } from '../utils'
 import { InvalidSASjsCsrfError } from '../types/errors/InvalidSASjsCsrfError'
+import { inspect } from 'util'
 
 export interface HttpClient {
   get<T>(
@@ -59,6 +60,7 @@ export interface HttpClient {
 export class RequestClient implements HttpClient {
   private requests: SASjsRequest[] = []
   private requestsLimit: number = 10
+  private httpInterceptor?: number
 
   protected csrfToken: CsrfToken = { headerName: '', value: '' }
   protected fileUploadCsrfToken: CsrfToken | undefined
@@ -70,6 +72,7 @@ export class RequestClient implements HttpClient {
     requestsLimit?: number
   ) {
     this.createHttpClient(baseUrl, httpsAgentOptions)
+
     if (requestsLimit) this.requestsLimit = requestsLimit
   }
 
@@ -180,6 +183,7 @@ export class RequestClient implements HttpClient {
       responseType: contentType === 'text/plain' ? 'text' : 'json',
       withCredentials: true
     }
+
     if (contentType === 'text/plain') {
       requestConfig.transformResponse = undefined
     }
@@ -387,6 +391,82 @@ export class RequestClient implements HttpClient {
         const logger = process.logger || console
         logger.error(error)
       })
+  }
+
+  private prettifyString = (str: any) => inspect(str, { colors: true })
+
+  private parseInterceptedBody = (body: any) => {
+    if (!body) return ''
+
+    let parsedBody
+
+    if (typeof body === 'string') {
+      try {
+        parsedBody = JSON.parse(body)
+      } catch (error) {
+        parsedBody = body
+      }
+    } else {
+      parsedBody = body
+    }
+
+    const bodyLines = this.prettifyString(parsedBody).split('\n')
+
+    if (bodyLines.length > 51) {
+      bodyLines.splice(50)
+      bodyLines.push('...')
+    }
+
+    return bodyLines.join('\n')
+  }
+
+  private defaultInterceptionCallBack = (response: AxiosResponse) => {
+    const { status, config, request, data: resData } = response
+    const { data: reqData } = config
+    const { _header: reqHeaders, res } = request
+    const { rawHeaders } = res
+
+    const resHeaders = rawHeaders.reduce(
+      (acc: string, value: string, i: number) => {
+        if (i % 2 === 0) {
+          acc += `${i === 0 ? '' : '\n'}${value}`
+        } else {
+          acc += `: ${value}`
+        }
+
+        return acc
+      },
+      ''
+    )
+
+    const parsedResBody = this.parseInterceptedBody(resData)
+
+    process.logger?.info(`HTTP Request (first 50 lines):
+${reqHeaders}${this.parseInterceptedBody(reqData)}
+
+HTTP Response Code: ${this.prettifyString(status)}
+
+HTTP Response (first 50 lines):
+${resHeaders}${parsedResBody ? `\n\n${parsedResBody}` : ''}
+`)
+
+    return response
+  }
+
+  public enableVerboseMode = (
+    successCallBack = this.defaultInterceptionCallBack,
+    errorCallBack = this.defaultInterceptionCallBack
+  ) => {
+    this.httpInterceptor = this.httpClient.interceptors.response.use(
+      successCallBack,
+      errorCallBack
+    )
+  }
+
+  public disableVerboseMode = () => {
+    if (this.httpInterceptor) {
+      this.httpClient.interceptors.response.eject(this.httpInterceptor)
+    }
   }
 
   protected getHeaders = (


### PR DESCRIPTION
## Issue

This feature has been added to support https://github.com/sasjs/cli/issues/1356.

## Intent

- Add a method that intercepts every HTTP response and logs its summary.
- Add a method that disables HTTP response interception.

## Implementation

- Added `enableVerboseMode` method to `RequestClient` class.
- Added `disableVerboseMode` method to `RequestClient` class.
- Added `defaultInterceptionCallBack` method to `RequestClient` class.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
