### PR TITLE
feat(request-client): made verbose mode easier to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The adapter will also cache the logs (if debug enabled) and even the work tables
 
 ### Verbose Mode
 
-Enabling debug will also enable a verbose mode that logs a summary of every HTTP response. Verbose mode can be disabled by calling `disableVerboseMode` method or enabled by `enableVerboseMode` method. Verbose mode can also be enabled/disabled by `startComputeJob` method.
+Set `verbose` to `true` to enable verbose mode that logs a summary of every HTTP response. Verbose mode can be disabled by calling `disableVerboseMode` method or enabled by `enableVerboseMode` method. Verbose mode can also be enabled/disabled by `startComputeJob` method.
 
 ### Session Manager
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ Configuration on the client side involves passing an object on startup, which ca
 * `appLoc` - this is the folder (eg in metadata or SAS Drive) under which the SAS services are created.
 * `serverType` - either `SAS9`, `SASVIYA` or `SASJS`.  The `SASJS` server type is for use with [sasjs/server](https://github.com/sasjs/server).
 * `serverUrl` - the location (including http protocol and port) of the SAS Server. Can be omitted, eg if serving directly from the SAS Web Server, or in streaming mode.
-* `debug` - if `true` then SAS Logs and extra debug information is returned. Setting debug to true will also enable a verbose mode that will log every HTTP response summary. 
+* `debug` - if `true` then SAS Logs and extra debug information is returned.
+* `verbose` - optional, if `true` then a summary of every HTTP response is logged.
 * `loginMechanism` - either `Default` or `Redirected`.  See [SAS Logon](#sas-logon) section.
 * `useComputeApi` - Only relevant when the serverType is `SASVIYA`. If `true` the [Compute API](#using-the-compute-api) is used.  If `false` the [JES API](#using-the-jes-api) is used.  If `null` or `undefined` the [Web](#using-jes-web-app) approach is used.
 * `contextName` - Compute context on which the requests will be called.  If missing or not provided, defaults to `Job Execution Compute context`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ The `request()` method also has optional parameters such as a config object and 
 
 The response object will contain returned tables and columns.  Table names are always lowercase, and column names uppercase.
 
-The adapter will also cache the logs (if debug enabled) and even the work tables.  For performance, it is best to keep debug mode off.
+The adapter will also cache the logs (if debug enabled) and even the work tables. For performance, it is best to keep debug mode off.
+
+### Verbose Mode
+
+Enabling debug will also enable a verbose mode that logs a summary of every HTTP response. Verbose mode can be disabled by calling `disableVerboseMode` method or enabled by `enableVerboseMode` method. Verbose mode can also be enabled/disabled by `startComputeJob` method.
 
 ### Session Manager
 
@@ -272,7 +276,7 @@ Configuration on the client side involves passing an object on startup, which ca
 * `appLoc` - this is the folder (eg in metadata or SAS Drive) under which the SAS services are created.
 * `serverType` - either `SAS9`, `SASVIYA` or `SASJS`.  The `SASJS` server type is for use with [sasjs/server](https://github.com/sasjs/server).
 * `serverUrl` - the location (including http protocol and port) of the SAS Server. Can be omitted, eg if serving directly from the SAS Web Server, or in streaming mode.
-* `debug` - if `true` then SAS Logs and extra debug information is returned.
+* `debug` - if `true` then SAS Logs and extra debug information is returned. Setting debug to true will also enable a verbose mode that will log every HTTP response summary. 
 * `loginMechanism` - either `Default` or `Redirected`.  See [SAS Logon](#sas-logon) section.
 * `useComputeApi` - Only relevant when the serverType is `SASVIYA`. If `true` the [Compute API](#using-the-compute-api) is used.  If `false` the [JES API](#using-the-jes-api) is used.  If `null` or `undefined` the [Web](#using-jes-web-app) approach is used.
 * `contextName` - Compute context on which the requests will be called.  If missing or not provided, defaults to `Job Execution Compute context`.

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -31,6 +31,7 @@ import {
 } from './job-execution'
 import { ErrorResponse } from './types/errors'
 import { LoginOptions, LoginResult } from './types/Login'
+import { AxiosResponse } from 'axios'
 
 interface ExecuteScriptParams {
   linesOfCode: string[]
@@ -880,7 +881,7 @@ export default class SASjs {
     }
 
     if (verboseMode) this.requestClient?.enableVerboseMode()
-    else this.requestClient?.disableVerboseMode()
+    else if (verboseMode === false) this.requestClient?.disableVerboseMode()
 
     return this.sasViyaApiClient?.executeComputeJob(
       sasJob,
@@ -975,7 +976,8 @@ export default class SASjs {
       this.requestClient = new RequestClientClass(
         this.sasjsConfig.serverUrl,
         this.sasjsConfig.httpsAgentOptions,
-        this.sasjsConfig.requestHistoryLimit
+        this.sasjsConfig.requestHistoryLimit,
+        this.sasjsConfig.debug // enable verbose mode if debug is true
       )
     } else {
       this.requestClient.setConfig(
@@ -1138,5 +1140,24 @@ export default class SASjs {
         )} servers.`
       )
     }
+  }
+
+  /**
+   * Enables verbose mode that will log a summary of every HTTP response.
+   * @param successCallBack - function that should be triggered on every HTTP response with the status 2**.
+   * @param errorCallBack - function that should be triggered on every HTTP response with the status different from 2**.
+   */
+  public enableVerboseMode(
+    successCallBack?: (response: AxiosResponse) => AxiosResponse,
+    errorCallBack?: (response: AxiosResponse) => AxiosResponse
+  ) {
+    this.requestClient?.enableVerboseMode(successCallBack, errorCallBack)
+  }
+
+  /**
+   * Turns off verbose mode to log every HTTP response.
+   */
+  public disableVerboseMode() {
+    this.requestClient?.disableVerboseMode()
   }
 }

--- a/src/SASjs.ts
+++ b/src/SASjs.ts
@@ -977,7 +977,7 @@ export default class SASjs {
         this.sasjsConfig.serverUrl,
         this.sasjsConfig.httpsAgentOptions,
         this.sasjsConfig.requestHistoryLimit,
-        this.sasjsConfig.debug // enable verbose mode if debug is true
+        this.sasjsConfig.verbose
       )
     } else {
       this.requestClient.setConfig(

--- a/src/minified/sas9/SASjs.ts
+++ b/src/minified/sas9/SASjs.ts
@@ -234,7 +234,7 @@ export default class SASjs {
         this.sasjsConfig.serverUrl,
         this.sasjsConfig.httpsAgentOptions,
         this.sasjsConfig.requestHistoryLimit,
-        this.sasjsConfig.debug // enable verbose mode if debug is true
+        this.sasjsConfig.verbose
       )
     } else {
       this.requestClient.setConfig(

--- a/src/minified/sas9/SASjs.ts
+++ b/src/minified/sas9/SASjs.ts
@@ -233,7 +233,8 @@ export default class SASjs {
       this.requestClient = new RequestClient(
         this.sasjsConfig.serverUrl,
         this.sasjsConfig.httpsAgentOptions,
-        this.sasjsConfig.requestHistoryLimit
+        this.sasjsConfig.requestHistoryLimit,
+        this.sasjsConfig.debug // enable verbose mode if debug is true
       )
     } else {
       this.requestClient.setConfig(

--- a/src/minified/sas9/WebJobExecutor.ts
+++ b/src/minified/sas9/WebJobExecutor.ts
@@ -11,7 +11,6 @@ import {
 import { RequestClient } from '../../request/RequestClient'
 import {
   isRelativePath,
-  parseSasViyaDebugResponse,
   appendExtraResponseAttributes,
   convertToCSV
 } from '../../utils'

--- a/src/request/RequestClient.ts
+++ b/src/request/RequestClient.ts
@@ -69,11 +69,14 @@ export class RequestClient implements HttpClient {
   constructor(
     protected baseUrl: string,
     httpsAgentOptions?: https.AgentOptions,
-    requestsLimit?: number
+    requestsLimit?: number,
+    verboseMode?: boolean
   ) {
     this.createHttpClient(baseUrl, httpsAgentOptions)
 
     if (requestsLimit) this.requestsLimit = requestsLimit
+
+    if (verboseMode) this.enableVerboseMode()
   }
 
   public setConfig(baseUrl: string, httpsAgentOptions?: https.AgentOptions) {

--- a/src/types/SASjsConfig.ts
+++ b/src/types/SASjsConfig.ts
@@ -46,6 +46,10 @@ export class SASjsConfig {
    */
   debug: boolean = true
   /**
+   * Set to `true` to enable verbose mode that will log a summary of every HTTP response.
+   */
+  verbose?: boolean = true
+  /**
    * The name of the compute context to use when calling the Viya services directly.
    * Example value: 'SAS Job Execution compute context'
    */


### PR DESCRIPTION
## Intent

- Add `verbose` option to `sasjsconfig`.
- Add public methods to enable/disable verbose mode.

## Implementation

- Changed the constructor method of `RequestClient` to make verbose mode configurable when an instance of `RequestClient` is instantiated.
- Added `enableVerboseMode` and `disableVerboseMode` public methods to `src/SASjs.ts`.
- Updated `README.md`.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
