### PR TITLE
chore(gh-action): fixed access token

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: uesteibar/reviewer-lottery@v1
         with:
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Push generated docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: ./docs 
+          publish_dir: ./docs
           cname: adapter.sasjs.io
 

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send Matrix message


### PR DESCRIPTION
## Intent

- Use `GITHUB_TOKEN` as an access token in github actions.

## Implementation

- Updated `.github/workflows/assign-reviewer.yml`.
- Updated `.github/workflows/generateDocs.yml`.
- Updated `.github/workflows/npmpublish.yml`.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.


- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [x] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
