### PR TITLE
fix(execute-script): fixed executing jobs on viya using compute api

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,10 +43,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      statements: 63.66,
-      branches: 44.74,
+      statements: 63.61,
+      branches: 44.72,
       functions: 53.94,
-      lines: 64.12
+      lines: 64.07
     }
   },
 

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -25,7 +25,7 @@ import { prefixMessage } from '@sasjs/utils/error'
 import { pollJobState } from './api/viya/pollJobState'
 import { getTokens } from './auth/getTokens'
 import { uploadTables } from './api/viya/uploadTables'
-import { executeScript } from './api/viya/executeScript'
+import { executeOnComputeApi } from './api/viya/executeOnComputeApi'
 import { getAccessTokenForViya } from './auth/getAccessTokenForViya'
 import { refreshTokensForViya } from './auth/refreshTokensForViya'
 
@@ -293,7 +293,7 @@ export class SASViyaApiClient {
     printPid = false,
     variables?: MacroVar
   ): Promise<any> {
-    return executeScript(
+    return executeOnComputeApi(
       this.requestClient,
       this.sessionManager,
       this.rootFolderName,

--- a/src/api/viya/executeOnComputeApi.ts
+++ b/src/api/viya/executeOnComputeApi.ts
@@ -20,7 +20,7 @@ interface JobRequestBody {
 }
 
 /**
- * Executes code on the current SAS Viya server.
+ * Executes SAS program on the current SAS Viya server using Compute API.
  * @param jobPath - the path to the file being submitted for execution.
  * @param linesOfCode - an array of code lines to execute.
  * @param contextName - the context to execute the code in.
@@ -33,7 +33,7 @@ interface JobRequestBody {
  * @param printPid - a boolean that indicates whether the function should print (PID) of the started job.
  * @param variables - an object that represents macro variables.
  */
-export async function executeScript(
+export async function executeOnComputeApi(
   requestClient: RequestClient,
   sessionManager: SessionManager,
   rootFolderName: string,
@@ -270,7 +270,7 @@ export async function executeScript(
     const error = e as HttpError
 
     if (error.status === 404) {
-      return executeScript(
+      return executeOnComputeApi(
         requestClient,
         sessionManager,
         rootFolderName,

--- a/src/api/viya/executeScript.ts
+++ b/src/api/viya/executeScript.ts
@@ -15,6 +15,10 @@ import { formatDataForRequest } from '../../utils/formatDataForRequest'
 import { pollJobState, JobState } from './pollJobState'
 import { uploadTables } from './uploadTables'
 
+interface JobRequestBody {
+  [key: string]: number | string | string[]
+}
+
 /**
  * Executes code on the current SAS Viya server.
  * @param jobPath - the path to the file being submitted for execution.
@@ -46,6 +50,7 @@ export async function executeScript(
   variables?: MacroVar
 ): Promise<any> {
   let access_token = (authConfig || {}).access_token
+
   if (authConfig) {
     ;({ access_token } = await getTokens(requestClient, authConfig))
   }
@@ -85,20 +90,6 @@ export async function executeScript(
       }
     }
 
-    const jobArguments: { [key: string]: any } = {
-      _contextName: contextName,
-      _OMITJSONLISTING: true,
-      _OMITJSONLOG: true,
-      _OMITSESSIONRESULTS: true,
-      _OMITTEXTLISTING: true,
-      _OMITTEXTLOG: true
-    }
-
-    if (debug) {
-      jobArguments['_OMITTEXTLOG'] = false
-      jobArguments['_OMITSESSIONRESULTS'] = false
-    }
-
     let fileName
 
     if (isRelativePath(jobPath)) {
@@ -107,6 +98,7 @@ export async function executeScript(
       }`
     } else {
       const jobPathParts = jobPath.split('/')
+
       fileName = jobPathParts.pop()
     }
 
@@ -118,7 +110,6 @@ export async function executeScript(
     }
 
     if (variables) jobVariables = { ...jobVariables, ...variables }
-
     if (debug) jobVariables = { ...jobVariables, _DEBUG: 131 }
 
     let files: any[] = []
@@ -145,12 +136,12 @@ export async function executeScript(
     }
 
     // Execute job in session
-    const jobRequestBody = {
-      name: fileName,
+    const jobRequestBody: JobRequestBody = {
+      name: fileName || 'Default Job Name',
       description: 'Powered by SASjs',
       code: linesOfCode,
       variables: jobVariables,
-      arguments: jobArguments
+      version: 2
     }
 
     const { result: postedJob, etag } = await requestClient

--- a/src/api/viya/spec/executeScript.spec.ts
+++ b/src/api/viya/spec/executeScript.spec.ts
@@ -217,14 +217,7 @@ describe('executeScript', () => {
           sasjs_tables: 'foo',
           sasjs0data: 'bar'
         },
-        arguments: {
-          _contextName: 'test context',
-          _OMITJSONLISTING: true,
-          _OMITJSONLOG: true,
-          _OMITSESSIONRESULTS: true,
-          _OMITTEXTLISTING: true,
-          _OMITTEXTLOG: true
-        }
+        version: 2
       },
       mockAuthConfig.access_token
     )
@@ -264,14 +257,7 @@ describe('executeScript', () => {
           sasjs0data: 'bar',
           _DEBUG: 131
         },
-        arguments: {
-          _contextName: 'test context',
-          _OMITJSONLISTING: true,
-          _OMITJSONLOG: true,
-          _OMITSESSIONRESULTS: false,
-          _OMITTEXTLISTING: true,
-          _OMITTEXTLOG: false
-        }
+        version: 2
       },
       mockAuthConfig.access_token
     )

--- a/src/api/viya/spec/executeScript.spec.ts
+++ b/src/api/viya/spec/executeScript.spec.ts
@@ -1,6 +1,6 @@
 import { RequestClient } from '../../../request/RequestClient'
 import { SessionManager } from '../../../SessionManager'
-import { executeScript } from '../executeScript'
+import { executeOnComputeApi } from '../executeOnComputeApi'
 import { mockSession, mockAuthConfig, mockJob } from './mockResponses'
 import * as pollJobStateModule from '../pollJobState'
 import * as uploadTablesModule from '../uploadTables'
@@ -25,7 +25,7 @@ describe('executeScript', () => {
   })
 
   it('should not try to get fresh tokens if an authConfig is not provided', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -38,7 +38,7 @@ describe('executeScript', () => {
   })
 
   it('should try to get fresh tokens if an authConfig is provided', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -55,7 +55,7 @@ describe('executeScript', () => {
   })
 
   it('should get a session from the session manager before executing', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -72,7 +72,7 @@ describe('executeScript', () => {
       .spyOn(sessionManager, 'getSession')
       .mockImplementation(() => Promise.reject('Test Error'))
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -85,7 +85,7 @@ describe('executeScript', () => {
   })
 
   it('should fetch the PID when printPid is true', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -113,7 +113,7 @@ describe('executeScript', () => {
       .spyOn(sessionManager, 'getVariable')
       .mockImplementation(() => Promise.reject('Test Error'))
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -139,7 +139,7 @@ describe('executeScript', () => {
         Promise.resolve([{ tableName: 'test', file: { id: 1 } }])
       )
 
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -163,7 +163,7 @@ describe('executeScript', () => {
   })
 
   it('should format data as CSV when it does not contain semicolons', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -189,7 +189,7 @@ describe('executeScript', () => {
       .spyOn(formatDataModule, 'formatDataForRequest')
       .mockImplementation(() => ({ sasjs_tables: 'foo', sasjs0data: 'bar' }))
 
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -228,7 +228,7 @@ describe('executeScript', () => {
       .spyOn(formatDataModule, 'formatDataForRequest')
       .mockImplementation(() => ({ sasjs_tables: 'foo', sasjs0data: 'bar' }))
 
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -268,7 +268,7 @@ describe('executeScript', () => {
       .spyOn(requestClient, 'post')
       .mockImplementation(() => Promise.reject('Test Error'))
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -288,7 +288,7 @@ describe('executeScript', () => {
   })
 
   it('should immediately return the session when waitForResult is false', async () => {
-    const result = await executeScript(
+    const result = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -308,7 +308,7 @@ describe('executeScript', () => {
   })
 
   it('should poll for job completion when waitForResult is true', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -338,7 +338,7 @@ describe('executeScript', () => {
       .spyOn(pollJobStateModule, 'pollJobState')
       .mockImplementation(() => Promise.reject('Poll Error'))
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -364,7 +364,7 @@ describe('executeScript', () => {
         Promise.reject({ response: { data: 'err=5113,' } })
       )
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -390,7 +390,7 @@ describe('executeScript', () => {
   })
 
   it('should fetch the logs for the job if debug is true and a log URL is available', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -415,7 +415,7 @@ describe('executeScript', () => {
   })
 
   it('should not fetch the logs for the job if debug is false', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -441,7 +441,7 @@ describe('executeScript', () => {
         Promise.resolve(pollJobStateModule.JobState.Failed)
       )
 
-    const error: ComputeJobExecutionError = await executeScript(
+    const error: ComputeJobExecutionError = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -476,7 +476,7 @@ describe('executeScript', () => {
         Promise.resolve(pollJobStateModule.JobState.Error)
       )
 
-    const error: ComputeJobExecutionError = await executeScript(
+    const error: ComputeJobExecutionError = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -505,7 +505,7 @@ describe('executeScript', () => {
   })
 
   it('should fetch the result if expectWebout is true', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -536,7 +536,7 @@ describe('executeScript', () => {
       return Promise.resolve({ result: mockJob, etag: '', status: 200 })
     })
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -570,7 +570,7 @@ describe('executeScript', () => {
   })
 
   it('should clear the session after execution is complete', async () => {
-    await executeScript(
+    await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',
@@ -597,7 +597,7 @@ describe('executeScript', () => {
       .spyOn(sessionManager, 'clearSession')
       .mockImplementation(() => Promise.reject('Clear Session Error'))
 
-    const error = await executeScript(
+    const error = await executeOnComputeApi(
       requestClient,
       sessionManager,
       'test',


### PR DESCRIPTION
## Issue

Closes #829 

## Intent

- Job arguments don't make sense during the execution of a SAS job using compute API and should not be part of the request body.

## Implementation

- Renamed `executeScript` to `executeOnComputeApi`.
- Removed `jobArguments` from the request body in `src/api/viya/executeOnComputeApi.ts`.
- Adjusted unit tests in `src/api/viya/spec/executeScript.spec.ts`.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
