### PR TITLE
feat(job-state): added session state check to doPoll func

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,10 +43,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      statements: 63.61,
-      branches: 44.72,
-      functions: 53.94,
-      lines: 64.07
+      statements: 64.01,
+      branches: 45.11,
+      functions: 54.1,
+      lines: 64.51
     }
   },
 

--- a/src/api/viya/spec/executeScript.spec.ts
+++ b/src/api/viya/spec/executeScript.spec.ts
@@ -7,7 +7,7 @@ import * as uploadTablesModule from '../uploadTables'
 import * as getTokensModule from '../../../auth/getTokens'
 import * as formatDataModule from '../../../utils/formatDataForRequest'
 import * as fetchLogsModule from '../../../utils/fetchLogByChunks'
-import { PollOptions } from '../../../types'
+import { PollOptions, JobSessionManager } from '../../../types'
 import { ComputeJobExecutionError, NotFoundError } from '../../../types/errors'
 import { Logger, LogLevel } from '@sasjs/utils/logger'
 
@@ -308,6 +308,11 @@ describe('executeScript', () => {
   })
 
   it('should poll for job completion when waitForResult is true', async () => {
+    const jobSessionManager: JobSessionManager = {
+      session: mockSession,
+      sessionManager: sessionManager
+    }
+
     await executeOnComputeApi(
       requestClient,
       sessionManager,
@@ -329,7 +334,8 @@ describe('executeScript', () => {
       mockJob,
       false,
       mockAuthConfig,
-      defaultPollOptions
+      defaultPollOptions,
+      jobSessionManager
     )
   })
 

--- a/src/api/viya/spec/mockResponses.ts
+++ b/src/api/viya/spec/mockResponses.ts
@@ -1,14 +1,16 @@
 import { AuthConfig } from '@sasjs/utils/types'
-import { Job, Session } from '../../../types'
+import { Job, Session, SessionState } from '../../../types'
 
 export const mockSession: Session = {
   id: 's35510n',
-  state: 'idle',
+  state: SessionState.Idle,
+  stateUrl: '',
   links: [],
   attributes: {
     sessionInactiveTimeout: 1
   },
-  creationTimeStamp: new Date().valueOf().toString()
+  creationTimeStamp: new Date().valueOf().toString(),
+  etag: 'etag-string'
 }
 
 export const mockJob: Job = {

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,15 +1,34 @@
 import { Link } from './Link'
+import { SessionManager } from '../SessionManager'
+
+export enum SessionState {
+  Completed = 'completed',
+  Running = 'running',
+  Pending = 'pending',
+  Idle = 'idle',
+  Unavailable = 'unavailable',
+  NoState = '',
+  Failed = 'failed',
+  Error = 'error'
+}
 
 export interface Session {
   id: string
-  state: string
+  state: SessionState
+  stateUrl: string
   links: Link[]
   attributes: {
     sessionInactiveTimeout: number
   }
   creationTimeStamp: string
+  etag: string
 }
 
 export interface SessionVariable {
   value: string
+}
+
+export interface JobSessionManager {
+  session: Session
+  sessionManager: SessionManager
 }


### PR DESCRIPTION
## Issue

Sometimes SAS API returns the job state `running` when the parent session is not in a `running` state.

## Intent

- Periodically (every 10th job state poll) check parent session state.

## Implementation

- Added parent session state check to `doPoll` function located at `src/api/viya/pollJobState.ts`.
- Adjusted `src/api/viya/executeOnComputeApi.ts`
- Refactored `src/SessionManager.ts`.
- Adjusted existing unit tests and covered new functionality.
- Updated unit test threshold.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [x] Unit tests coverage has been increased and a new threshold is set.
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
