### PR TITLE
fix(poll-job-state): fixed checking session state

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,10 +43,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      statements: 64.01,
+      statements: 64.03,
       branches: 45.11,
-      functions: 54.1,
-      lines: 64.51
+      functions: 54.18,
+      lines: 64.53
     }
   },
 

--- a/src/api/viya/spec/pollJobState.spec.ts
+++ b/src/api/viya/spec/pollJobState.spec.ts
@@ -465,7 +465,7 @@ describe('doPoll', () => {
       .spyOn(sessionManager as any, 'getSessionState')
       .mockImplementation(() => {
         return Promise.resolve({
-          result: SessionState.Running,
+          result: SessionState.Idle,
           responseStatus: 200
         })
       })
@@ -533,9 +533,9 @@ describe('doPoll', () => {
     )
   })
 
-  it('should throw an error if session is not in running state', async () => {
+  it('should throw an error if session state is not healthy', async () => {
     const filteredSessionStates = Object.values(SessionState).filter(
-      (state) => state !== SessionState.Running
+      (state) => state !== SessionState.Running && state !== SessionState.Idle
     )
     const randomSessionState =
       filteredSessionStates[
@@ -580,7 +580,7 @@ describe('doPoll', () => {
       new JobStatePollError(
         mockJob.id,
         new Error(
-          `Session state of the job is not 'running'. Session state is '${randomSessionState}'`
+          `Session state of the job is not 'running' or 'idle'. Session state is '${randomSessionState}'`
         )
       )
     )


### PR DESCRIPTION
## Issue

Parent session may be in a not healthy state (`running` or `idle`) while checking SAS job state.

## Intent

- Add `idle` as a healthy parent session state.

## Implementation

- Added `isSessionStatesHealthy` utility to  `src/api/viya/pollJobState.ts`.
- Adjusted unit tests covering `doPoll` function.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
