### PR TITLE
Viya JES approach workaround, job arguments are case-sensitive and webout was not returned

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -870,14 +870,14 @@ export class SASViyaApiClient {
       _webin_file_count: files.length,
       _OMITJSONLISTING: true,
       _OMITJSONLOG: true,
-      _OMITSESSIONRESULTS: true,
+      _omitSessionResults: false,
       _OMITTEXTLISTING: true,
       _OMITTEXTLOG: true
     }
 
     if (debug) {
       jobArguments['_OMITTEXTLOG'] = 'false'
-      jobArguments['_OMITSESSIONRESULTS'] = 'false'
+      jobArguments['_omitSessionResults'] = 'false'
       jobArguments['_DEBUG'] = 131
     }
 

--- a/src/job-execution/JobExecutor.ts
+++ b/src/job-execution/JobExecutor.ts
@@ -51,7 +51,7 @@ export abstract class BaseJobExecutor implements JobExecutor {
 
     if (config.debug) {
       requestParams['_omittextlog'] = 'false'
-      requestParams['_omitsessionresults'] = 'false'
+      requestParams['_omitSessionResults'] = 'false'
 
       requestParams['_debug'] = 131
     }

--- a/src/test/RequestClient.spec.ts
+++ b/src/test/RequestClient.spec.ts
@@ -104,7 +104,7 @@ Connection: close
             _contextName: 'SAS Job Execution compute context',
             _OMITJSONLISTING: true,
             _OMITJSONLOG: true,
-            _OMITSESSIONRESULTS: true,
+            _omitSessionResults: true,
             _OMITTEXTLISTING: true,
             _OMITTEXTLOG: true
           }


### PR DESCRIPTION
## Issue

https://documentation.sas.com/doc/zh-cn/sasadmincdc/v_021/caljobs/n0t21mf756sv0en1kd176kky8upt.htm

https://communities.sas.com/t5/SAS-Viya/Returning-webout-from-JES-API/td-p/966992

## Intent

Sending request using JES API approach does not return `_webout.json`, because job argument `_OMITSESSIONRESULTS` is by default `true` and is case sensitive so we should send `_omitSessionResults` instead.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
