### PR TITLE
Viya upload and arguments

### DIFF
--- a/.github/workflows/build-unit-tests.yml
+++ b/.github/workflows/build-unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/utils": "^3.5.6",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "axios-cookiejar-support": "5.0.5",
         "form-data": "4.0.4",
         "https": "1.0.0",
@@ -86,7 +86,6 @@
       "version": "7.26.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -131,6 +130,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -157,6 +157,7 @@
       "version": "7.26.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -177,6 +178,7 @@
       "version": "7.26.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "regexpu-core": "^6.2.0",
@@ -193,6 +195,7 @@
       "version": "0.6.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -208,6 +211,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -248,6 +252,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -267,6 +272,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-wrap-function": "^7.25.9",
@@ -283,6 +289,7 @@
       "version": "7.26.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -299,6 +306,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -335,6 +343,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/traverse": "^7.25.9",
@@ -374,6 +383,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -389,6 +399,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -403,6 +414,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -417,6 +429,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
@@ -433,6 +446,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -448,6 +462,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -514,6 +529,7 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -710,6 +726,7 @@
       "version": "7.18.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -725,6 +742,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -739,6 +757,7 @@
       "version": "7.26.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
@@ -755,6 +774,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -771,6 +791,7 @@
       "version": "7.26.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -785,6 +806,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -799,6 +821,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -814,6 +837,7 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -829,6 +853,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -848,6 +873,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/template": "^7.25.9"
@@ -863,6 +889,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -877,6 +904,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -892,6 +920,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -906,6 +935,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -921,6 +951,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -935,6 +966,7 @@
       "version": "7.26.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -949,6 +981,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -963,6 +996,7 @@
       "version": "7.26.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -978,6 +1012,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -994,6 +1029,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1008,6 +1044,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1022,6 +1059,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1036,6 +1074,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1050,6 +1089,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1065,6 +1105,7 @@
       "version": "7.26.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.26.0",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1080,6 +1121,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1097,6 +1139,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1112,6 +1155,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1127,6 +1171,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1141,6 +1186,7 @@
       "version": "7.26.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -1155,6 +1201,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1169,6 +1216,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1185,6 +1233,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-replace-supers": "^7.25.9"
@@ -1200,6 +1249,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1214,6 +1264,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1229,6 +1280,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1243,6 +1295,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1258,6 +1311,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1274,6 +1328,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1288,6 +1343,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
@@ -1303,6 +1359,7 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1318,6 +1375,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1332,6 +1390,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1346,6 +1405,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1361,6 +1421,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1375,6 +1436,7 @@
       "version": "7.26.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -1389,6 +1451,7 @@
       "version": "7.26.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -1403,6 +1466,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1417,6 +1481,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1432,6 +1497,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1447,6 +1513,7 @@
       "version": "7.25.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1545,6 +1612,7 @@
       "version": "0.1.6-no-external-plugins",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1558,6 +1626,7 @@
       "version": "7.26.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2187,7 +2256,6 @@
       "version": "4.2.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -3148,7 +3216,6 @@
       "version": "8.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3217,7 +3284,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3461,12 +3527,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -3601,6 +3667,7 @@
       "version": "0.4.12",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.6.3",
@@ -3614,6 +3681,7 @@
       "version": "0.11.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3",
         "core-js-compat": "^3.40.0"
@@ -3626,6 +3694,7 @@
       "version": "0.6.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -3720,6 +3789,7 @@
       "version": "5.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3938,7 +4008,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4395,7 +4464,8 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -4578,6 +4648,7 @@
       "version": "3.40.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.24.3"
       },
@@ -5366,6 +5437,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5402,7 +5474,6 @@
       "version": "2.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -6016,6 +6087,7 @@
       "version": "3.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -7334,7 +7406,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8471,6 +8542,7 @@
       "version": "2.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -8504,7 +8576,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -8634,6 +8707,7 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -8674,7 +8748,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12666,12 +12739,14 @@
     "node_modules/regenerate": {
       "version": "1.4.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -12682,12 +12757,14 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
@@ -12696,6 +12773,7 @@
       "version": "6.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -12722,12 +12800,14 @@
     "node_modules/regjsgen": {
       "version": "0.8.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -12739,6 +12819,7 @@
       "version": "3.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -12950,6 +13031,7 @@
       "version": "2.7.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
@@ -12967,7 +13049,6 @@
       "version": "19.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
@@ -14013,7 +14094,6 @@
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -14433,7 +14513,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14458,6 +14537,7 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14466,6 +14546,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -14478,6 +14559,7 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14486,6 +14568,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14745,7 +14828,6 @@
       "version": "5.76.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -14792,7 +14874,6 @@
       "version": "4.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "main": "index.js",
   "dependencies": {
     "@sasjs/utils": "^3.5.6",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "axios-cookiejar-support": "5.0.5",
     "form-data": "4.0.4",
     "https": "1.0.0",

--- a/sasjs-tests/package-lock.json
+++ b/sasjs-tests/package-lock.json
@@ -12,6 +12,31 @@
         "vite": "npm:rolldown-vite@7.2.2"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -19,6 +44,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -642,7 +668,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -755,14 +780,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/vite": {
       "name": "rolldown-vite",

--- a/sasjs-tests/public/config.json
+++ b/sasjs-tests/public/config.json
@@ -4,8 +4,8 @@
   "sasJsConfig": {
     "loginMechanism": "Redirected",
     "serverUrl": "",
-    "appLoc": "/Public/app/adapter-tests/services",
-    "serverType": "SASVIYA",
+    "appLoc": "/Public/app/adapter-tests",
+    "serverType": "SASJS",
     "debug": false,
     "contextName": "SAS Job Execution compute context",
     "useComputeApi": true

--- a/sasjs-tests/src/components/TestCard.ts
+++ b/sasjs-tests/src/components/TestCard.ts
@@ -72,7 +72,7 @@ export class TestCard extends HTMLElement {
           ? `
         <div class="error">
           <strong>Error:</strong>
-          <pre>${(error as Error).message || String(error)}</pre>
+          <pre>${formatError(error)}</pre>
         </div>
       `
           : ''
@@ -107,6 +107,37 @@ export class TestCard extends HTMLElement {
       default:
         return '?'
     }
+  }
+}
+
+const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+const formatError = (err: unknown): string => {
+  if (err == null) return ''
+  if (typeof err === 'string') return escapeHtml(err)
+
+  const anyErr = err as any
+  // Adapter ErrorResponse: { error: { message, details, raw } }
+  const nestedMsg = anyErr?.error?.message
+  const directMsg = anyErr?.message
+  const msg = directMsg || nestedMsg
+
+  if (msg) {
+    const details = anyErr?.error?.details ?? anyErr?.details
+    const detailsStr =
+      details && typeof details === 'object'
+        ? `\n${JSON.stringify(details, null, 2)}`
+        : details
+          ? `\n${details}`
+          : ''
+    return escapeHtml(`${msg}${detailsStr}`)
+  }
+
+  try {
+    return escapeHtml(JSON.stringify(err, null, 2))
+  } catch {
+    return escapeHtml(String(err))
   }
 }
 

--- a/sasjs-tests/src/main.ts
+++ b/sasjs-tests/src/main.ts
@@ -22,6 +22,7 @@ import { sendArrTests, sendObjTests } from './testSuites/RequestData'
 import { fileUploadTests } from './testSuites/FileUpload'
 import { computeTests } from './testSuites/Compute'
 import { sasjsRequestTests } from './testSuites/SasjsRequests'
+import { specialCaseTests } from './testSuites/SpecialCases'
 
 async function init() {
   const appContainer = document.getElementById('app')
@@ -98,7 +99,7 @@ function showTests(
     // basicTests(adapter, configTyped.userName || '', configTyped.password || ''),
     sendArrTests(adapter, appLoc),
     sendObjTests(adapter),
-    // specialCaseTests(adapter),
+    specialCaseTests(adapter),
     sasjsRequestTests(adapter),
     fileUploadTests(adapter)
   ]

--- a/sasjs-tests/src/testSuites/Basic.ts
+++ b/sasjs-tests/src/testSuites/Basic.ts
@@ -77,7 +77,7 @@ export const basicTests = (
         await adapter.logOut()
 
         return await adapter.request(
-          'common/sendArr',
+          'services/common/sendArr',
           stringData,
           undefined,
           async () => {
@@ -97,7 +97,11 @@ export const basicTests = (
           useComputeApi: false
         }
 
-        return await adapter.request('common/sendArr', stringData, config)
+        return await adapter.request(
+          'services/common/sendArr',
+          stringData,
+          config
+        )
       },
       assertion: (response: any) => {
         return response.table1[0][0] === stringData.table1[0].col1
@@ -112,7 +116,11 @@ export const basicTests = (
           debug: true
         }
 
-        return await adapter.request('common/sendArr', stringData, config)
+        return await adapter.request(
+          'services/common/sendArr',
+          stringData,
+          config
+        )
       },
       assertion: (response: any) => {
         return response.table1[0][0] === stringData.table1[0].col1

--- a/sasjs-tests/src/testSuites/Compute.ts
+++ b/sasjs-tests/src/testSuites/Compute.ts
@@ -11,7 +11,7 @@ export const computeTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Compute API request',
       description: 'Should run the request with compute API approach',
       test: async () => {
-        return await adapter.request('common/sendArr', stringData)
+        return await adapter.request('services/common/sendArr', stringData)
       },
       assertion: (response: any) => {
         return response.table1[0][0] === stringData.table1[0].col1
@@ -25,7 +25,11 @@ export const computeTests = (adapter: SASjs, appLoc: string): TestSuite => ({
           useComputeApi: false
         }
 
-        return await adapter.request('common/sendArr', stringData, config)
+        return await adapter.request(
+          'services/common/sendArr',
+          stringData,
+          config
+        )
       },
       assertion: (response: any) => {
         return response.table1[0][0] === stringData.table1[0].col1
@@ -36,7 +40,10 @@ export const computeTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       description: 'Should start a compute job and return the session',
       test: () => {
         const data: any = { table1: [{ col1: 'first col value' }] }
-        return adapter.startComputeJob(`${appLoc}/common/sendArr`, data)
+        return adapter.startComputeJob(
+          `${appLoc}/services/common/sendArr`,
+          data
+        )
       },
       assertion: (res: any) => {
         const expectedProperties = ['id', 'applicationName', 'attributes']
@@ -49,7 +56,7 @@ export const computeTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       test: () => {
         const data: any = { table1: [{ col1: 'first col value' }] }
         return adapter.startComputeJob(
-          `${appLoc}/common/sendArr`,
+          `${appLoc}/services/common/sendArr`,
           data,
           {},
           undefined,

--- a/sasjs-tests/src/testSuites/FileUpload.ts
+++ b/sasjs-tests/src/testSuites/FileUpload.ts
@@ -22,7 +22,11 @@ export const fileUploadTests = (adapter: SASjs): TestSuite => ({
           }
         ]
 
-        return adapter.uploadFile('common/sendMacVars', filesToUpload, null)
+        return adapter.uploadFile(
+          'services/common/sendMacVars',
+          filesToUpload,
+          null
+        )
       },
       assertion: (response: any) =>
         (response.macvars as any[]).findIndex(

--- a/sasjs-tests/src/testSuites/RequestData.ts
+++ b/sasjs-tests/src/testSuites/RequestData.ts
@@ -53,7 +53,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Absolute paths',
       description: 'Should work with absolute paths to SAS jobs',
       test: () => {
-        return adapter.request(`${appLoc}/common/sendArr`, stringData)
+        return adapter.request(`${appLoc}/services/common/sendArr`, stringData)
       },
       assertion: (res: any) => {
         return res.table1[0][0] === stringData.table1[0].col1
@@ -63,7 +63,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Single string value',
       description: 'Should send an array with a single string value',
       test: () => {
-        return adapter.request('common/sendArr', stringData)
+        return adapter.request('services/common/sendArr', stringData)
       },
       assertion: (res: any) => {
         return res.table1[0][0] === stringData.table1[0].col1
@@ -74,7 +74,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       description:
         'Should send an array with a long string value under 32765 characters',
       test: () => {
-        return adapter.request('common/sendArr', getLongStringData())
+        return adapter.request('services/common/sendArr', getLongStringData())
       },
       assertion: (res: any) => {
         const longStringData = getLongStringData()
@@ -87,7 +87,9 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
         'Should error out with long string values over 32765 characters',
       test: () => {
         const data = getLongStringData(32767)
-        return adapter.request('common/sendArr', data).catch((e: any) => e)
+        return adapter
+          .request('services/common/sendArr', data)
+          .catch((e: any) => e)
       },
       assertion: (error: any) => {
         return !!error && !!error.error && !!error.error.message
@@ -97,7 +99,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Single numeric value',
       description: 'Should send an array with a single numeric value',
       test: () => {
-        return adapter.request('common/sendArr', numericData)
+        return adapter.request('services/common/sendArr', numericData)
       },
       assertion: (res: any) => {
         return res.table1[0][0] === numericData.table1[0].col1
@@ -107,7 +109,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Multiple columns',
       description: 'Should handle data with multiple columns',
       test: () => {
-        return adapter.request('common/sendArr', multiColumnData)
+        return adapter.request('services/common/sendArr', multiColumnData)
       },
       assertion: (res: any) => {
         return (
@@ -122,7 +124,7 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Multiple rows with nulls',
       description: 'Should handle data with multiple rows with null values',
       test: () => {
-        return adapter.request('common/sendArr', multipleRowsWithNulls)
+        return adapter.request('services/common/sendArr', multipleRowsWithNulls)
       },
       assertion: (res: any) => {
         let result = true
@@ -148,7 +150,10 @@ export const sendArrTests = (adapter: SASjs, appLoc: string): TestSuite => ({
       title: 'Multiple columns with nulls',
       description: 'Should handle data with multiple columns with null values',
       test: () => {
-        return adapter.request('common/sendArr', multipleColumnsWithNulls)
+        return adapter.request(
+          'services/common/sendArr',
+          multipleColumnsWithNulls
+        )
       },
       assertion: (res: any) => {
         let result = true
@@ -184,7 +189,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           '1InvalidTable': [{ col1: 42 }]
         }
         return adapter
-          .request('common/sendObj', invalidData)
+          .request('services/common/sendObj', invalidData)
           .catch((e: any) => e)
       },
       assertion: (error: any) =>
@@ -198,7 +203,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           'an invalidTable': [{ col1: 42 }]
         }
         return adapter
-          .request('common/sendObj', invalidData)
+          .request('services/common/sendObj', invalidData)
           .catch((e: any) => e)
       },
       assertion: (error: any) =>
@@ -212,7 +217,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           'anInvalidTable#': [{ col1: 42 }]
         }
         return adapter
-          .request('common/sendObj', invalidData)
+          .request('services/common/sendObj', invalidData)
           .catch((e: any) => e)
       },
       assertion: (error: any) =>
@@ -227,7 +232,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
         }
 
         return adapter
-          .request('common/sendObj', invalidData)
+          .request('services/common/sendObj', invalidData)
           .catch((e: any) => e)
       },
       assertion: (error: any) =>
@@ -241,7 +246,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
           inData: [[{ data: 'value' }]]
         }
         return adapter
-          .request('common/sendObj', invalidData)
+          .request('services/common/sendObj', invalidData)
           .catch((e: any) => e)
       },
       assertion: (error: any) =>
@@ -251,7 +256,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Single string value',
       description: 'Should send an object with a single string value',
       test: () => {
-        return adapter.request('common/sendObj', stringData)
+        return adapter.request('services/common/sendObj', stringData)
       },
       assertion: (res: any) => {
         return res.table1[0].COL1 === stringData.table1[0].col1
@@ -262,7 +267,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       description:
         'Should send an object with a long string value under 32765 characters',
       test: () => {
-        return adapter.request('common/sendObj', getLongStringData())
+        return adapter.request('services/common/sendObj', getLongStringData())
       },
       assertion: (res: any) => {
         const longStringData = getLongStringData()
@@ -275,7 +280,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
         'Should error out with long string values over 32765 characters',
       test: () => {
         return adapter
-          .request('common/sendObj', getLongStringData(32767))
+          .request('services/common/sendObj', getLongStringData(32767))
           .catch((e: any) => e)
       },
       assertion: (error: any) => {
@@ -286,7 +291,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Single numeric value',
       description: 'Should send an object with a single numeric value',
       test: () => {
-        return adapter.request('common/sendObj', numericData)
+        return adapter.request('services/common/sendObj', numericData)
       },
       assertion: (res: any) => {
         return res.table1[0].COL1 === numericData.table1[0].col1
@@ -297,7 +302,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Large data volume',
       description: 'Should send an object with a large amount of data',
       test: () => {
-        return adapter.request('common/sendObj', getLargeObjectData())
+        return adapter.request('services/common/sendObj', getLargeObjectData())
       },
       assertion: (res: any) => {
         const data = getLargeObjectData()
@@ -308,7 +313,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Multiple columns',
       description: 'Should handle data with multiple columns',
       test: () => {
-        return adapter.request('common/sendObj', multiColumnData)
+        return adapter.request('services/common/sendObj', multiColumnData)
       },
       assertion: (res: any) => {
         return (
@@ -323,7 +328,7 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Multiple rows with nulls',
       description: 'Should handle data with multiple rows with null values',
       test: () => {
-        return adapter.request('common/sendObj', multipleRowsWithNulls)
+        return adapter.request('services/common/sendObj', multipleRowsWithNulls)
       },
       assertion: (res: any) => {
         let result = true
@@ -349,7 +354,10 @@ export const sendObjTests = (adapter: SASjs): TestSuite => ({
       title: 'Multiple columns with nulls',
       description: 'Should handle data with multiple columns with null values',
       test: () => {
-        return adapter.request('common/sendObj', multipleColumnsWithNulls)
+        return adapter.request(
+          'services/common/sendObj',
+          multipleColumnsWithNulls
+        )
       },
       assertion: (res: any) => {
         let result = true

--- a/sasjs-tests/src/testSuites/SasjsRequests.ts
+++ b/sasjs-tests/src/testSuites/SasjsRequests.ts
@@ -11,7 +11,7 @@ export const sasjsRequestTests = (adapter: SASjs): TestSuite => ({
       title: 'WORK tables',
       description: 'Should get WORK tables after request',
       test: async () => {
-        return adapter.request('common/sendArr', data)
+        return adapter.request('services/common/sendArr', data)
       },
       assertion: () => {
         const requests = adapter.getSasRequests()
@@ -28,7 +28,7 @@ export const sasjsRequestTests = (adapter: SASjs): TestSuite => ({
     //     'Should make an error and capture log, in the same time it is testing if debug override is working',
     //   test: async () => {
     //     return adapter
-    //       .request('common/makeErr', data, { debug: true })
+    //       .request('services/common/makeErr', data, { debug: true })
     //       .catch(() => {
     //         const sasRequests = adapter.getSasRequests()
     //         const makeErrRequest: any =

--- a/sasjs-tests/src/testSuites/SpecialCases.ts
+++ b/sasjs-tests/src/testSuites/SpecialCases.ts
@@ -111,7 +111,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Common special characters',
       description: 'Should handle common special characters',
       test: () => {
-        return adapter.request('common/sendArr', specialCharData)
+        return adapter.request('services/common/sendArr', specialCharData)
       },
       assertion: (res: any) => {
         return (
@@ -133,7 +133,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Other special characters',
       description: 'Should handle other special characters',
       test: () => {
-        return adapter.request('common/sendArr', moreSpecialCharData)
+        return adapter.request('services/common/sendArr', moreSpecialCharData)
       },
       assertion: (res: any) => {
         // If sas session is `latin9` or `wlatin1` we can't process the special characters,
@@ -169,7 +169,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Wide table with sendArr',
       description: 'Should handle data with 10000 columns',
       test: () => {
-        return adapter.request('common/sendArr', getWideData())
+        return adapter.request('services/common/sendArr', getWideData())
       },
       assertion: (res: any) => {
         const data = getWideData()
@@ -185,7 +185,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Wide table with sendObj',
       description: 'Should handle data with 10000 columns',
       test: () => {
-        return adapter.request('common/sendObj', getWideData())
+        return adapter.request('services/common/sendObj', getWideData())
       },
       assertion: (res: any) => {
         const data = getWideData()
@@ -202,7 +202,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Multiple tables',
       description: 'Should handle data with 100 tables',
       test: () => {
-        return adapter.request('common/sendArr', getTables())
+        return adapter.request('services/common/sendArr', getTables())
       },
       assertion: (res: any) => {
         const data = getTables()
@@ -222,7 +222,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Large dataset with sendObj',
       description: 'Should handle 5mb of data',
       test: () => {
-        return adapter.request('common/sendObj', getLargeDataset())
+        return adapter.request('services/common/sendObj', getLargeDataset())
       },
       assertion: (res: any) => {
         const data = getLargeDataset()
@@ -237,7 +237,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Large dataset with sendArr',
       description: 'Should handle 5mb of data',
       test: () => {
-        return adapter.request('common/sendArr', getLargeDataset())
+        return adapter.request('services/common/sendArr', getLargeDataset())
       },
       assertion: (res: any) => {
         const data = getLargeDataset()
@@ -253,7 +253,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Error and _csrf tables with sendArr',
       description: 'Should handle error and _csrf tables',
       test: () => {
-        return adapter.request('common/sendArr', errorAndCsrfData)
+        return adapter.request('services/common/sendArr', errorAndCsrfData)
       },
       assertion: (res: any) => {
         return (
@@ -272,7 +272,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Error and _csrf tables with sendObj',
       description: 'Should handle error and _csrf tables',
       test: () => {
-        return adapter.request('common/sendObj', errorAndCsrfData)
+        return adapter.request('services/common/sendObj', errorAndCsrfData)
       },
       assertion: (res: any) => {
         return (
@@ -300,7 +300,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
         }
 
         return await adapter.request(
-          'common/sendArr',
+          'services/common/sendArr',
           stringData,
           config,
           undefined,
@@ -319,7 +319,10 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
       title: 'Special missing values',
       description: 'Should support special missing values',
       test: () => {
-        return adapter.request('common/sendObj', testTableWithSpecialNumeric)
+        return adapter.request(
+          'services/common/sendObj',
+          testTableWithSpecialNumeric
+        )
       },
       assertion: (res: any) => {
         let assertionRes = true
@@ -365,7 +368,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
         'Should support special missing values, when one row is send',
       test: () => {
         return adapter.request(
-          'common/sendObj',
+          'services/common/sendObj',
           testTableWithSpecialNumericOneRow
         )
       },
@@ -413,7 +416,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
         'Should support special missing values, when LOWERCASE value is sent',
       test: () => {
         return adapter.request(
-          'common/sendObj',
+          'services/common/sendObj',
           testTableWithSpecialNumericLowercase
         )
       },
@@ -469,7 +472,7 @@ export const specialCaseTests = (adapter: SASjs): TestSuite => ({
         'Should support special missing values, when one row is send (On VIYA Web Approach)',
       test: () => {
         return adapter.request(
-          'common/sendObj',
+          'services/common/sendObj',
           testTableWithSpecialNumericOneRow,
           { useComputeApi: undefined }
         )

--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -1031,11 +1031,17 @@ export class SASViyaApiClient {
       jobArguments[`_webin_name${index + 1}`] = fileInfo.tableName
     })
 
+    // Viya JES requires arguments to be Map<String,String>; coerce booleans/numbers.
+    const stringifiedArguments: { [key: string]: string } = {}
+    for (const k of Object.keys(jobArguments)) {
+      stringifiedArguments[k] = String(jobArguments[k])
+    }
+
     const postJobRequestBody = {
       name: `exec-${jobName}`,
       description: 'Powered by SASjs',
       jobDefinition,
-      arguments: jobArguments
+      arguments: stringifiedArguments
     }
 
     const { result: postedJob } = await this.requestClient.post<Job>(

--- a/src/api/viya/spec/uploadTables.spec.ts
+++ b/src/api/viya/spec/uploadTables.spec.ts
@@ -23,6 +23,20 @@ describe('uploadTables', () => {
     )
   })
 
+  it('should skip $tablename formats metadata keys', async () => {
+    const data = {
+      tablewith2cols2rows: [{ col1: 'val1', specialMissingsCol: 'A' }],
+      $tablewith2cols2rows: { formats: { specialMissingsCol: 'best.' } }
+    }
+
+    const files = await uploadTables(requestClient, data, 't0k3n')
+
+    expect(files).toEqual([
+      { tableName: 'tablewith2cols2rows', file: 'test-file' }
+    ])
+    expect(requestClient.uploadFile).toHaveBeenCalledTimes(1)
+  })
+
   it('should throw an error when the CSV exceeds the maximum length', async () => {
     const data = { foo: 'bar' }
     jest

--- a/src/api/viya/uploadTables.ts
+++ b/src/api/viya/uploadTables.ts
@@ -1,6 +1,6 @@
 import { prefixMessage } from '@sasjs/utils/error'
 import { RequestClient } from '../../request/RequestClient'
-import { convertToCSV } from '../../utils/convertToCsv'
+import { convertToCSV, isFormatsTable } from '../../utils/convertToCsv'
 
 /**
  * Uploads tables to SAS as specially formatted CSVs.
@@ -18,6 +18,10 @@ export async function uploadTables(
   const uploadedFiles = []
 
   for (const tableName in data) {
+    // $tablename keys carry only column-format metadata for the matching
+    // tablename payload; they must not be uploaded as separate files.
+    if (isFormatsTable(tableName)) continue
+
     const csv = convertToCSV(data, tableName)
     if (csv === 'ERROR: LARGE STRING LENGTH') {
       throw new Error(


### PR DESCRIPTION
## Intent

Fix two Viya bugs surfaced when running the test app and improve the test suite.

1. On the JES path (`useComputeApi: false`), the adapter was uploading an extra empty CSV for every `$tablename` key.
2. JES POST `/jobExecution/jobs` rejected requests with `400 The field "arguments" in the request body contains an incorrect data type`. Per the official Job Execution v7 OpenAPI spec, `arguments` is `Map<String,String>``additionalProperties: { type: string }`). The adapter was sending booleans (`_OMITJSONLISTING: true`) and numbers (`_webin_file_count: 1`, `_DEBUG: 131`).
3. Test app failures rendered as `Error: [object Object]` because `TestCard` only checked `.message`, while the adapter throws `ErrorResponse` (`error.error.message`).

## Implementation

* **`src/api/viya/uploadTables.ts`** — skip keys where `isFormatsTable`
    returns true so `$tablename` metadata is never uploaded as a file.
 * **`src/SASViyaApiClient.ts`** — coerce all `jobArguments` values to
    strings.
 * **`sasjs-tests/src/components/TestCard.ts`** — added `formatError()`
    helper.

## Checks

No PR (that involves a non-trivial code change) should be merged, unless all items below are confirmed!  If an urgent fix is needed - use a tar file.

- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- (CI Runs this) All `sasjs-tests` are passing. If you want to run it manually (instructions available [here](https://github.com/sasjs/adapter/blob/master/sasjs-tests/README.md)).
- [ ] [Data Controller](https://datacontroller.io) builds and is functional on both SAS 9 and Viya
